### PR TITLE
add basic persistency API

### DIFF
--- a/TPPCommon/Models/Model.cs
+++ b/TPPCommon/Models/Model.cs
@@ -1,0 +1,9 @@
+﻿namespace TPPCommon.Models
+{
+    /// <summary>
+    /// base class for all data models that might get handled by the persistency layer.
+    /// </summary>
+    public abstract class Model
+    {
+    }
+}

--- a/TPPCommon/Models/User.cs
+++ b/TPPCommon/Models/User.cs
@@ -1,0 +1,42 @@
+﻿namespace TPPCommon.Models
+{
+    /// <summary>
+    /// model for user objects.
+    /// </summary>
+    public class User : Model
+    {
+        /// <summary>
+        /// unique id of the user.
+        /// </summary>
+        public readonly string Id;
+        
+        /// <summary>
+        /// user id that the (chat) service, which this user originates from, provided.
+        /// </summary>
+        public readonly string ProvidedId;
+        
+        /// <summary>
+        /// name of the (chat) service this user originates from.
+        /// </summary>
+        public readonly string ProvidedName;
+        
+        /// <summary>
+        /// name of the user. this is how he is being displayed.
+        /// </summary>
+        public readonly string Name;
+        
+        /// <summary>
+        /// simple name of this user. usually maps to lowercase-variations from irc. only contains ASCII.
+        /// </summary>
+        public readonly string SimpleName;
+
+        public User(string id, string providedId, string name, string simpleName, string providedName)
+        {
+            Id = id;
+            ProvidedId = providedId;
+            Name = name;
+            SimpleName = simpleName;
+            ProvidedName = providedName;
+        }
+    }
+}

--- a/TPPCommon/Models/User.cs
+++ b/TPPCommon/Models/User.cs
@@ -1,35 +1,45 @@
-﻿namespace TPPCommon.Models
+﻿using MongoDB.Bson.Serialization.Attributes;
+using TPPCommon.Persistence;
+
+namespace TPPCommon.Models
 {
     /// <summary>
     /// model for user objects.
     /// </summary>
+    [Table("users")]
     public class User : Model
     {
         /// <summary>
         /// unique id of the user.
         /// </summary>
+        [BsonId]
         public readonly string Id;
         
         /// <summary>
         /// user id that the (chat) service, which this user originates from, provided.
         /// </summary>
+        [BsonElement("provided_id")]
         public readonly string ProvidedId;
         
         /// <summary>
         /// name of the (chat) service this user originates from.
         /// </summary>
+        [BsonElement("provided_name")]
         public readonly string ProvidedName;
         
         /// <summary>
         /// name of the user. this is how he is being displayed.
         /// </summary>
+        [BsonElement("name")]
         public readonly string Name;
         
         /// <summary>
         /// simple name of this user. usually maps to lowercase-variations from irc. only contains ASCII.
         /// </summary>
+        [BsonElement("simple_name")]
         public readonly string SimpleName;
 
+        [BsonConstructor]
         public User(string id, string providedId, string name, string simpleName, string providedName)
         {
             Id = id;

--- a/TPPCommon/Persistence/IPersistence.cs
+++ b/TPPCommon/Persistence/IPersistence.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq.Expressions;
+using TPPCommon.Models;
+
+namespace TPPCommon.Persistence
+{
+    /// <summary>
+    /// a persistency layer which is capable of storing and retrieving instances of
+    /// <see cref="Model"/> in some sort of persistent datastorage, like a database.
+    /// </summary>
+    public interface IPersistence
+    {
+        /// <summary>
+        /// Saves a <see cref="Model"/> to the persistency layer.
+        /// Throws an exception if the model already existed in the persistency layer.
+        /// </summary>
+        void Save<TModel>(TModel model) where TModel : Model;
+        
+        /// <summary>
+        /// Replaces an existing model within the persistency layer with a new one.
+        /// </summary>
+        /// <param name="expression">expression defining what model to match</param>
+        /// <param name="replacement">replacement for the model</param>
+        /// <param name="upsert">true, if the replacement model should be saved if it didn't exist</param>
+        void ReplaceOne<TModel>(Expression<Func<TModel, bool>> expression, TModel replacement, bool upsert = true) where TModel : Model;
+        
+        /// <summary>
+        /// Searches for a model and returns the first match.
+        /// </summary>
+        /// <param name="expression">expression defining what model to match</param>
+        /// <returns>The object found, or null if none was found.</returns>
+        TModel FindOne<TModel>(Expression<Func<TModel, bool>> expression) where TModel : Model;
+    }
+}

--- a/TPPCommon/Persistence/MongoPersistence.cs
+++ b/TPPCommon/Persistence/MongoPersistence.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Security;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using TPPCommon.Models;
+
+namespace TPPCommon.Persistence
+{
+    /// <summary>
+    /// Implementation of <see cref="IPersistence"/> using MongoDB.
+    /// </summary>
+    public class MongoPersistence : IPersistence
+    {
+        private readonly IDictionary<Type, string> _collectionLookup;
+        private readonly ISet<string> _usedCollectionNames;
+        private readonly MongoClient _client;
+        private readonly IMongoDatabase _database;
+
+        public MongoPersistence(string host, int port, string database) : this(host, port, database, null, null)
+        {
+        }
+
+        public MongoPersistence(string host, int port, string database, string username, SecureString password)
+        {
+            var clientSettings = new MongoClientSettings
+            {
+                Server = new MongoServerAddress(host, port)
+            };
+            if (username != null && password != null)
+            {
+                clientSettings.Credentials = new[] {MongoCredential.CreateCredential(database, username, password)}; 
+            }
+            password?.Dispose();
+            _client = new MongoClient(clientSettings);
+            _database = _client.GetDatabase(database);
+            _collectionLookup = new Dictionary<Type, string>();
+            _usedCollectionNames = new HashSet<string>();
+            Init();
+        }
+        
+        private void Init()
+        {
+            // Associate Models with MongoDB collection names
+            RegisterCollection<User>("users");
+            
+            // Set up MongoDB mappings
+            BsonClassMap.RegisterClassMap<User>(cm =>
+            {
+                cm.MapIdMember(m => m.Id);
+                cm.MapMember(m => m.ProvidedId).SetElementName("provided_id");
+                cm.MapMember(m => m.ProvidedName).SetElementName("provided_name");
+                cm.MapMember(m => m.Name).SetElementName("name");
+                cm.MapMember(m => m.SimpleName).SetElementName("simple_name");
+                cm.MapCreator(m => new User(m.Id, m.ProvidedId, m.Name, m.SimpleName, m.ProvidedName));
+            });
+        }
+
+        private void RegisterCollection<TModel>(string collectionName) where TModel : Model
+        {
+            if (_usedCollectionNames.Contains(collectionName))
+            {
+                throw new ArgumentException("Collection name already in use: " + collectionName);
+            }
+            _collectionLookup.Add(typeof(TModel), collectionName);
+            _usedCollectionNames.Add(collectionName);
+        }
+
+        private IMongoCollection<T> GetCollection<T>()
+        {
+            var type = typeof(T);
+            if (!_collectionLookup.ContainsKey(type))
+            {
+                throw new ArgumentException("No collection is registered for type " + type);
+            }
+            var collectionName = _collectionLookup[type];
+            return _database.GetCollection<T>(collectionName);
+        }
+
+        public void Save<TModel>(TModel model) where TModel : Model
+        {
+            GetCollection<TModel>().InsertOne(model);
+        }
+
+        public void ReplaceOne<TModel>(Expression<Func<TModel, bool>> expression, TModel replacement, bool upsert = true) where TModel : Model
+        {
+            GetCollection<TModel>().ReplaceOne(expression, replacement, new UpdateOptions {IsUpsert = upsert});
+        }
+        
+        public TModel FindOne<TModel>(Expression<Func<TModel, bool>> expression) where TModel : Model
+        {
+            var result = GetCollection<TModel>().Find(expression);
+            return result.Any() ? result.Single() : null;
+        }
+    }
+}

--- a/TPPCommon/Persistence/TableAttribute.cs
+++ b/TPPCommon/Persistence/TableAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace TPPCommon.Persistence
+{
+    /// <summary>
+    /// Attribute used for giving a model the name of the logical unit it gets persisted in.
+    /// For SQL this would equivalent to the table name, for MongoDB to the collection name.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class TableAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the logical unit.
+        /// For SQL this is equivalent to the table name, for MongoDB to the collection name.
+        /// </summary>
+        public readonly string Table;
+
+        /// <summary>
+        /// Regex to restrict possible table names to a widely supported subset.
+        /// In this case only lowercase, numbers, and underscores. 
+        /// </summary>
+        private const string NameRegex = @"^[a-z][a-z0-9_]*$";
+
+        public TableAttribute(string table)
+        {
+            if (!Regex.IsMatch(table, NameRegex))
+            {
+                throw new ArgumentException($"table names must match this regex: '{NameRegex}'");
+            }
+
+            Table = table;
+        }
+    }
+}

--- a/TPPCommon/TPPCommon.csproj
+++ b/TPPCommon/TPPCommon.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
     <PackageReference Include="NetMQ" Version="4.0.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />

--- a/TestPersistence/Program.cs
+++ b/TestPersistence/Program.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq.Expressions;
+using TPPCommon.Models;
+using TPPCommon.Persistence;
+
+namespace TestDatabaseThing
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            IPersistence persistence = new MongoPersistence("localhost", 27017, "tpp-new");
+
+            const string id = "asdf123456";
+            Expression<Func<User, bool>> idExpression = u => u.Id==id;
+            
+            var user = new User(
+                id,
+                "qwertzuiop",
+                "Felkbot",
+                "felkbot",
+                "Félkböt");
+            
+//            persistence.Save(user);
+            
+            persistence.ReplaceOne(idExpression, user);
+            
+            var loadedUser = persistence.FindOne(idExpression);
+            
+            Console.WriteLine(loadedUser.ProvidedName);
+        }
+    }
+}

--- a/TestPersistence/TestPersistence.csproj
+++ b/TestPersistence/TestPersistence.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TPPCommon\TPPCommon.csproj" />
+  </ItemGroup>
+</Project>

--- a/TppCore.sln
+++ b/TppCore.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TPPCommon", "TPPCommon\TPPC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TPPCommonTest", "TPPCommonTest\TPPCommonTest.csproj", "{EE8F97DE-DC32-46C6-8680-03A91389B41F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPersistence", "TestPersistence\TestPersistence.csproj", "{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{EE8F97DE-DC32-46C6-8680-03A91389B41F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE8F97DE-DC32-46C6-8680-03A91389B41F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE8F97DE-DC32-46C6-8680-03A91389B41F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
These changes add an `IPersistence` interface, which supports saving and loading of arbitrary `Model` classes. The interface's methods are surely not final, nor complete or ideal, but a start.

There's also an implementation for MongoDB and a test project for seeing it in action.