### PR TITLE
Create logging service and pub-sub proxy

### DIFF
--- a/LogService/ILogger.cs
+++ b/LogService/ILogger.cs
@@ -35,8 +35,9 @@ namespace LogService
         /// Log an error message along with its exception.
         /// </summary>
         /// <param name="message">log message</param>
-        /// <param name="e">exception</param>
-        void LogError(string message, Exception e);
+        /// <param name="exceptionMessage">exception message</param>
+        /// <param name="stackTrace">exception stack trace</param>
+        void LogError(string message, string exceptionMessage, string stackTrace);
 
         /// <summary>
         /// Log a critical error message.
@@ -48,7 +49,8 @@ namespace LogService
         /// Log a critical error message along with its exception.
         /// </summary>
         /// <param name="message">log message</param>
-        /// <param name="e">exception</param>
-        void LogCritical(string message, Exception e);
+        /// <param name="exceptionMessage">exception message</param>
+        /// <param name="stackTrace">exception stack trace</param>
+        void LogCritical(string message, string exceptionMessage, string stackTrace);
     }
 }

--- a/LogService/ILogger.cs
+++ b/LogService/ILogger.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace LogService
+{
+    /// <summary>
+    /// Interface for logging messages.
+    /// </summary>
+    internal interface ILogger
+    {
+        /// <summary>
+        /// Log a debug message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogDebug(string message);
+
+        /// <summary>
+        /// Log a general information message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogInfo(string message);
+
+        /// <summary>
+        /// Log a warning message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogWarning(string message);
+
+        /// <summary>
+        /// Log an error message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogError(string message);
+
+        /// <summary>
+        /// Log an error message along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        void LogError(string message, Exception e);
+
+        /// <summary>
+        /// Log a critical error message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogCritical(string message);
+
+        /// <summary>
+        /// Log a critical error message along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        void LogCritical(string message, Exception e);
+    }
+}

--- a/LogService/Log4NetLogger.cs
+++ b/LogService/Log4NetLogger.cs
@@ -80,10 +80,11 @@ namespace LogService
         /// Log an error message along with its exception.
         /// </summary>
         /// <param name="message">log message</param>
-        /// <param name="e">exception</param>
-        public void LogError(string message, Exception e)
+        /// <param name="exceptionMessage">exception message</param>
+        /// <param name="stackTrace">exception stack trace</param>
+        public void LogError(string message, string exceptionMessage, string stackTrace)
         {
-            Log4NetLogger.Log.Error(ApplyPrefix(message), e);
+            Log4NetLogger.Log.Error($"{ApplyPrefix(message)}{Environment.NewLine}{exceptionMessage}{Environment.NewLine}{stackTrace}");
         }
 
         /// <summary>
@@ -99,10 +100,11 @@ namespace LogService
         /// Log a critical error message along with its exception.
         /// </summary>
         /// <param name="message">log message</param>
-        /// <param name="e">exception</param>
-        public void LogCritical(string message, Exception e)
+        /// <param name="exceptionMessage">exception message</param>
+        /// <param name="stackTrace">exception stack trace</param>
+        public void LogCritical(string message, string exceptionMessage, string stackTrace)
         {
-            Log4NetLogger.Log.Fatal(ApplyPrefix(message), e);
+            Log4NetLogger.Log.Fatal($"{ApplyPrefix(message)}{Environment.NewLine}{exceptionMessage}{Environment.NewLine}{stackTrace}");
         }
     }
 }

--- a/LogService/Log4NetLogger.cs
+++ b/LogService/Log4NetLogger.cs
@@ -11,7 +11,6 @@ namespace LogService
     internal class Log4NetLogger : ILogger
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(Log4NetLogger));
-        private string Prefix = string.Empty;
 
         static Log4NetLogger()
         {
@@ -27,26 +26,12 @@ namespace LogService
         }
 
         /// <summary>
-        /// Specifies a prefix to add to all log messages.
-        /// </summary>
-        /// <param name="prefixMessage">log message prefix</param>
-        public void SetLogPrefix(string prefixMessage)
-        {
-            this.Prefix = prefixMessage ?? string.Empty;
-        }
-
-        private string ApplyPrefix(string message)
-        {
-            return this.Prefix + message;
-        }
-
-        /// <summary>
         /// Log a debug message.
         /// </summary>
         /// <param name="message">log message</param>
         public void LogDebug(string message)
         {
-            Log4NetLogger.Log.Debug(ApplyPrefix(message));
+            Log4NetLogger.Log.Debug(message);
         }
 
         /// <summary>
@@ -55,7 +40,7 @@ namespace LogService
         /// <param name="message">log message</param>
         public void LogInfo(string message)
         {
-            Log4NetLogger.Log.Info(ApplyPrefix(message));
+            Log4NetLogger.Log.Info(message);
         }
 
         /// <summary>
@@ -64,7 +49,7 @@ namespace LogService
         /// <param name="message">log message</param>
         public void LogWarning(string message)
         {
-            Log4NetLogger.Log.Warn(ApplyPrefix(message));
+            Log4NetLogger.Log.Warn(message);
         }
 
         /// <summary>
@@ -73,7 +58,7 @@ namespace LogService
         /// <param name="message">log message</param>
         public void LogError(string message)
         {
-            Log4NetLogger.Log.Error(ApplyPrefix(message));
+            Log4NetLogger.Log.Error(message);
         }
 
         /// <summary>
@@ -84,7 +69,7 @@ namespace LogService
         /// <param name="stackTrace">exception stack trace</param>
         public void LogError(string message, string exceptionMessage, string stackTrace)
         {
-            Log4NetLogger.Log.Error($"{ApplyPrefix(message)}{Environment.NewLine}{exceptionMessage}{Environment.NewLine}{stackTrace}");
+            Log4NetLogger.Log.Error($"{message}{Environment.NewLine}{exceptionMessage}{Environment.NewLine}{stackTrace}");
         }
 
         /// <summary>
@@ -93,7 +78,7 @@ namespace LogService
         /// <param name="message">log message</param>
         public void LogCritical(string message)
         {
-            Log4NetLogger.Log.Fatal(ApplyPrefix(message));
+            Log4NetLogger.Log.Fatal(message);
         }
 
         /// <summary>
@@ -104,7 +89,7 @@ namespace LogService
         /// <param name="stackTrace">exception stack trace</param>
         public void LogCritical(string message, string exceptionMessage, string stackTrace)
         {
-            Log4NetLogger.Log.Fatal($"{ApplyPrefix(message)}{Environment.NewLine}{exceptionMessage}{Environment.NewLine}{stackTrace}");
+            Log4NetLogger.Log.Fatal($"{message}{Environment.NewLine}{exceptionMessage}{Environment.NewLine}{stackTrace}");
         }
     }
 }

--- a/LogService/Log4NetLogger.cs
+++ b/LogService/Log4NetLogger.cs
@@ -1,0 +1,108 @@
+﻿using log4net;
+using log4net.Config;
+using log4net.Repository.Hierarchy;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Xml;
+
+namespace LogService
+{
+    internal class Log4NetLogger : ILogger
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(Log4NetLogger));
+        private string Prefix = string.Empty;
+
+        static Log4NetLogger()
+        {
+            // Manually load the log4net configuration file.
+            XmlDocument config = new XmlDocument();
+
+            string assemblyDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+            string configPath = Path.Combine(assemblyDirectory, "log4net.config");
+            config.Load(File.OpenRead(configPath));
+
+            var repository = LogManager.CreateRepository(Assembly.GetEntryAssembly(), typeof(Hierarchy));
+            XmlConfigurator.Configure(repository, config["log4net"]);
+        }
+
+        /// <summary>
+        /// Specifies a prefix to add to all log messages.
+        /// </summary>
+        /// <param name="prefixMessage">log message prefix</param>
+        public void SetLogPrefix(string prefixMessage)
+        {
+            this.Prefix = prefixMessage ?? string.Empty;
+        }
+
+        private string ApplyPrefix(string message)
+        {
+            return this.Prefix + message;
+        }
+
+        /// <summary>
+        /// Log a debug message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogDebug(string message)
+        {
+            Log4NetLogger.Log.Debug(ApplyPrefix(message));
+        }
+
+        /// <summary>
+        /// Log a general information message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogInfo(string message)
+        {
+            Log4NetLogger.Log.Info(ApplyPrefix(message));
+        }
+
+        /// <summary>
+        /// Log a warning message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogWarning(string message)
+        {
+            Log4NetLogger.Log.Warn(ApplyPrefix(message));
+        }
+
+        /// <summary>
+        /// Log an error message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogError(string message)
+        {
+            Log4NetLogger.Log.Error(ApplyPrefix(message));
+        }
+
+        /// <summary>
+        /// Log an error message along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        public void LogError(string message, Exception e)
+        {
+            Log4NetLogger.Log.Error(ApplyPrefix(message), e);
+        }
+
+        /// <summary>
+        /// Log a critical error message.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogCritical(string message)
+        {
+            Log4NetLogger.Log.Fatal(ApplyPrefix(message));
+        }
+
+        /// <summary>
+        /// Log a critical error message along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        public void LogCritical(string message, Exception e)
+        {
+            Log4NetLogger.Log.Fatal(ApplyPrefix(message), e);
+        }
+    }
+}

--- a/LogService/LogService.cs
+++ b/LogService/LogService.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
+using TPPCommon.PubSub;
+using TPPCommon.PubSub.Events;
+
+namespace LogService
+{
+    /// <summary>
+    /// Central service responsible for handling all TPP logging events, and writing them to the appropriate places.
+    /// </summary>
+    internal class LogService
+    {
+        private ISubscriber Subscriber;
+        private ILogger Logger;
+
+        public LogService(ISubscriber subscriber, ILogger logger)
+        {
+            this.Subscriber = subscriber;
+            this.Logger = logger;
+        }
+
+        internal void Run()
+        {
+            // Setup dependency injection, to hide the pub-sub implementation.
+            var serviceCollection = new ServiceCollection()
+                .AddTransient<ILogger, Log4NetLogger>()
+                .AddTransient<ISubscriber, ZMQSubscriber>()
+                .AddTransient<LogService>()
+                .AddTransient<IPubSubEventSerializer, JSONPubSubEventSerializer>()
+                .AddTransient<ZMQPublisher>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Subscribe to all log events.
+            this.Subscriber.Subscribe<LogDebugEvent>(log => this.Logger.LogDebug(log.Message));
+            this.Subscriber.Subscribe<LogInfoEvent>(log => this.Logger.LogInfo(log.Message));
+            this.Subscriber.Subscribe<LogWarningEvent>(log => this.Logger.LogWarning(log.Message));
+            this.Subscriber.Subscribe<LogErrorEvent>(log => this.Logger.LogError(log.Message, log.Exception));
+            this.Subscriber.Subscribe<LogCriticalEvent>(log => this.Logger.LogCritical(log.Message, log.Exception));
+
+            // Block forever.
+            new AutoResetEvent(false).WaitOne();
+        }
+    }
+}

--- a/LogService/LogService.cs
+++ b/LogService/LogService.cs
@@ -34,10 +34,13 @@ namespace LogService
             this.Subscriber.Subscribe<LogDebugEvent>(log => this.Logger.LogDebug(log.Message));
             this.Subscriber.Subscribe<LogInfoEvent>(log => this.Logger.LogInfo(log.Message));
             this.Subscriber.Subscribe<LogWarningEvent>(log => this.Logger.LogWarning(log.Message));
-            this.Subscriber.Subscribe<LogErrorEvent>(log => this.Logger.LogError(log.Message, log.Exception));
-            this.Subscriber.Subscribe<LogCriticalEvent>(log => this.Logger.LogCritical(log.Message, log.Exception));
+            this.Subscriber.Subscribe<LogErrorEvent>(log => this.Logger.LogError(log.Message));
+            this.Subscriber.Subscribe<LogErrorExceptionEvent>(log => this.Logger.LogError(log.Message, log.ExceptionMessage, log.StackTrace));
+            this.Subscriber.Subscribe<LogCriticalEvent>(log => this.Logger.LogCritical(log.Message));
+            this.Subscriber.Subscribe<LogCriticalExceptionEvent>(log => this.Logger.LogCritical(log.Message, log.ExceptionMessage, log.StackTrace));
 
             // Block forever.
+            this.Logger.LogDebug("Logging service running...");
             new AutoResetEvent(false).WaitOne();
         }
     }

--- a/LogService/LogService.csproj
+++ b/LogService/LogService.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TPPCommon\TPPCommon.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="log4net.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/LogService/Program.cs
+++ b/LogService/Program.cs
@@ -1,27 +1,24 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using TPPCommon.Logging;
 using TPPCommon.PubSub;
 using TPPCommon.PubSub.Events;
 
-namespace TestClient
+namespace LogService
 {
     class Program
     {
         static void Main(string[] args)
         {
-            // Setup dependency injection, to hide the pub-sub implementation.
+            // Setup dependency injection, to hide implementations.
             var serviceCollection = new ServiceCollection()
+                .AddTransient<ILogger, Log4NetLogger>()
                 .AddTransient<IPubSubEventSerializer, JSONPubSubEventSerializer>()
                 .AddTransient<ZMQSubscriber>()
                 .AddTransient<ISubscriber, ZMQSubscriber>()
-                .AddTransient<IPublisher, ZMQPublisher>()
-                .AddTransient<TPPLogger>()
-                .AddTransient<TestClient>();
+                .AddTransient<LogService>();
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
-            // Run client.
-            TestClient client = serviceProvider.GetService<TestClient>();
-            client.Run();
+            LogService logService = serviceProvider.GetService<LogService>();
+            logService.Run();
         }
     }
 }

--- a/LogService/log4net.config
+++ b/LogService/log4net.config
@@ -9,7 +9,7 @@
     <rollingStyle value="Date" />
     <datePattern value=".yyyy-MM-dd" />--><!-- New log file each day. --><!--
     <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="[%-5p] %utcdate{yyyy-MM-dd HH:mm:ss} %message%newline" />
+      <conversionPattern value="%utcdate{yyyy-MM-dd HH:mm:ss} [%-5p] %message%newline" />
     </layout>
     <threshold value="info" />
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />--><!-- Allow multiple processes to log to same file. --><!--
@@ -17,7 +17,7 @@
   
   <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
     <layout type="log4net.Layout.PatternLayout">
-      <conversionPattern value="%-5level-> %message%newline" />
+      <conversionPattern value="%utcdate{yyyy-MM-dd HH:mm:ss} [%-5p] %message%newline" />
     </layout>
     <threshold value="all" />
   </appender>

--- a/LogService/log4net.config
+++ b/LogService/log4net.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<log4net>
+
+  <!-- Uncomment to enable rolling file logging.
+       Remember to uncomment the <appender-ref> below in the <root> node, too.-->
+  <!--<appender name="RollingFile" type="log4net.Appender.RollingFileAppender">
+    <file value="D:\TPPLogs\tpplog.txt" />
+    <appendToFile value="true" />
+    <rollingStyle value="Date" />
+    <datePattern value=".yyyy-MM-dd" />--><!-- New log file each day. --><!--
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="[%-5p] %utcdate{yyyy-MM-dd HH:mm:ss} %message%newline" />
+    </layout>
+    <threshold value="info" />
+    <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />--><!-- Allow multiple processes to log to same file. --><!--
+  </appender>-->
+  
+  <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+    <layout type="log4net.Layout.PatternLayout">
+      <conversionPattern value="%-5level-> %message%newline" />
+    </layout>
+    <threshold value="all" />
+  </appender>
+  <root>
+    <!--<appender-ref ref="RollingFile" />-->
+    <appender-ref ref="ConsoleAppender" />
+  </root>
+</log4net>

--- a/PubSubBroker/Program.cs
+++ b/PubSubBroker/Program.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using TPPCommon.PubSub;
+
+namespace PubSubBroker
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // Setup dependency injection, to hide the pub-sub implementation.
+            var serviceCollection = new ServiceCollection()
+                .AddTransient<IBroker, ZMQBroker>()
+                .AddTransient<PubSubBroker>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            // Run client.
+            PubSubBroker broker = serviceProvider.GetService<PubSubBroker>();
+            broker.Run();
+        }
+    }
+}

--- a/PubSubBroker/Program.cs
+++ b/PubSubBroker/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Threading;
 using TPPCommon.PubSub;
 
 namespace PubSubBroker

--- a/PubSubBroker/PubSubBroker.cs
+++ b/PubSubBroker/PubSubBroker.cs
@@ -1,0 +1,19 @@
+﻿using TPPCommon.PubSub;
+
+namespace PubSubBroker
+{
+    class PubSubBroker
+    {
+        private IBroker Broker;
+
+        public PubSubBroker(IBroker broker)
+        {
+            this.Broker = broker;
+        }
+
+        public void Run()
+        {
+            this.Broker.Run();
+        }
+    }
+}

--- a/PubSubBroker/PubSubBroker.csproj
+++ b/PubSubBroker/PubSubBroker.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TPPCommon\TPPCommon.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TPPCommon/Addresses.cs
+++ b/TPPCommon/Addresses.cs
@@ -10,9 +10,14 @@ namespace TPPCommon
     public class Addresses
     {
         /// <summary>
-        /// The port used for pub-sub communication. TODO: This assumes only a single port is used for all pub-sub events.
+        /// The port used for the publishers in pub-sub communication.
         /// </summary>
-        public const int PubSubPort = 1337;
+        public const int PublisherPort = 1337;
+
+        /// <summary>
+        /// The port used for the subscribers in pub-sub communication.
+        /// </summary>
+        public const int SubscriberPort = 1338;
 
         /// <summary>
         /// Base network address for localhost.

--- a/TPPCommon/Logging/ITPPLogger.cs
+++ b/TPPCommon/Logging/ITPPLogger.cs
@@ -16,44 +16,51 @@ namespace TPPCommon.Logging
         /// Log a debug event.
         /// </summary>
         /// <param name="message">log message</param>
-        void LogDebug(string message);
+        /// <param name="args">string format args</param>
+        void LogDebug(string message, params object[] args);
 
         /// <summary>
         /// Log a general information event.
         /// </summary>
         /// <param name="message">log message</param>
-        void LogInfo(string message);
+        /// <param name="args">string format args</param>
+        void LogInfo(string message, params object[] args);
 
         /// <summary>
         /// Log a warning event.
         /// </summary>
         /// <param name="message">log message</param>
-        void LogWarning(string message);
+        /// <param name="args">string format args</param>
+        void LogWarning(string message, params object[] args);
 
         /// <summary>
         /// Log an error event.
         /// </summary>
         /// <param name="message">log message</param>
-        void LogError(string message);
+        /// <param name="args">string format args</param>
+        void LogError(string message, params object[] args);
 
         /// <summary>
         /// Log an error event along with its exception.
         /// </summary>
         /// <param name="message">log message</param>
         /// <param name="e">exception</param>
-        void LogError(string message, Exception e);
+        /// <param name="args">string format args</param>
+        void LogError(string message, Exception e, params object[] args);
 
         /// <summary>
         /// Log a critical error event.
         /// </summary>
         /// <param name="message">log message</param>
-        void LogCritical(string message);
+        /// <param name="args">string format args</param>
+        void LogCritical(string message, params object[] args);
 
         /// <summary>
         /// Log a critical error event along with its exception.
         /// </summary>
         /// <param name="message">log message</param>
         /// <param name="e">exception</param>
-        void LogCritical(string message, Exception e);
+        /// <param name="args">string format args</param>
+        void LogCritical(string message, Exception e, params object[] args);
     }
 }

--- a/TPPCommon/Logging/ITPPLogger.cs
+++ b/TPPCommon/Logging/ITPPLogger.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TPPCommon.Logging
+{
+    public interface ITPPLogger
+    {
+        /// <summary>
+        /// Specifies a prefix to add to all log messages.
+        /// </summary>
+        /// <param name="prefixMessage">log message prefix</param>
+        void SetLogPrefix(string prefixMessage);
+
+        /// <summary>
+        /// Log a debug event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogDebug(string message);
+
+        /// <summary>
+        /// Log a general information event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogInfo(string message);
+
+        /// <summary>
+        /// Log a warning event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogWarning(string message);
+
+        /// <summary>
+        /// Log an error event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogError(string message);
+
+        /// <summary>
+        /// Log an error event along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        void LogError(string message, Exception e);
+
+        /// <summary>
+        /// Log a critical error event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        void LogCritical(string message);
+
+        /// <summary>
+        /// Log a critical error event along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        void LogCritical(string message, Exception e);
+    }
+}

--- a/TPPCommon/Logging/TPPDebugLogger.cs
+++ b/TPPCommon/Logging/TPPDebugLogger.cs
@@ -5,9 +5,16 @@ using TPPCommon.PubSub.Events;
 
 namespace TPPCommon.Logging
 {
-    public class TPPDebugLogger : ITPPLogger
+    /// <summary>
+    /// Class which TPP services directly use to perform logging.
+    /// This class isn't responsible for perform the actual logging, rather it publishes logging
+    /// events, to which a logging service can listen.
+    /// 
+    /// This is meant to be used during local development, because it writes logs directly to the console, in addition to
+    /// publishing log events.
+    /// </summary>
+    public class TPPDebugLogger : TPPLoggerBase, ITPPLogger
     {
-        private string Prefix = string.Empty;
         private IPublisher Publisher;
 
         public TPPDebugLogger(IPublisher publisher)
@@ -48,36 +55,40 @@ namespace TPPCommon.Logging
         /// Log a debug event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogDebug(string message)
+        /// <param name="args">string format args</param>
+        public void LogDebug(string message, params object[] args)
         {
-            this.PublishLog(new LogDebugEvent(ApplyPrefix(message)), "DEBUG");
+            this.PublishLog(new LogDebugEvent(this.NormalizeMessage(message, args)), "DEBUG");
         }
 
         /// <summary>
         /// Log a general information event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogInfo(string message)
+        /// <param name="args">string format args</param>
+        public void LogInfo(string message, params object[] args)
         {
-            this.PublishLog(new LogInfoEvent(ApplyPrefix(message)), "INFO ");
+            this.PublishLog(new LogInfoEvent(this.NormalizeMessage(message, args)), "INFO ");
         }
 
         /// <summary>
         /// Log a warning event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogWarning(string message)
+        /// <param name="args">string format args</param>
+        public void LogWarning(string message, params object[] args)
         {
-            this.PublishLog(new LogWarningEvent(ApplyPrefix(message)), "WARN ");
+            this.PublishLog(new LogWarningEvent(this.NormalizeMessage(message, args)), "WARN ");
         }
 
         /// <summary>
         /// Log an error event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogError(string message)
+        /// <param name="args">string format args</param>
+        public void LogError(string message, params object[] args)
         {
-            this.PublishLog(new LogErrorEvent(ApplyPrefix(message)), "ERROR");
+            this.PublishLog(new LogErrorEvent(this.NormalizeMessage(message, args)), "ERROR");
         }
 
         /// <summary>
@@ -85,18 +96,20 @@ namespace TPPCommon.Logging
         /// </summary>
         /// <param name="message">log message</param>
         /// <param name="e">exception</param>
-        public void LogError(string message, Exception e)
+        /// <param name="args">string format args</param>
+        public void LogError(string message, Exception e, params object[] args)
         {
-            this.PublishLog(new LogErrorExceptionEvent(ApplyPrefix(message), e?.Message, e?.StackTrace), "ERROR");
+            this.PublishLog(new LogErrorExceptionEvent(this.NormalizeMessage(message, args), e?.Message, e?.StackTrace), "ERROR");
         }
 
         /// <summary>
         /// Log a critical error event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogCritical(string message)
+        /// <param name="args">string format args</param>
+        public void LogCritical(string message, params object[] args)
         {
-            this.PublishLog(new LogCriticalEvent(ApplyPrefix(message)), "FATAL");
+            this.PublishLog(new LogCriticalEvent(this.NormalizeMessage(message, args)), "FATAL");
         }
 
         /// <summary>
@@ -104,9 +117,10 @@ namespace TPPCommon.Logging
         /// </summary>
         /// <param name="message">log message</param>
         /// <param name="e">exception</param>
-        public void LogCritical(string message, Exception e)
+        /// <param name="args">string format args</param>
+        public void LogCritical(string message, Exception e, params object[] args)
         {
-            this.PublishLog(new LogCriticalExceptionEvent(ApplyPrefix(message), e?.Message, e?.StackTrace), "FATAL");
+            this.PublishLog(new LogCriticalExceptionEvent(this.NormalizeMessage(message, args), e?.Message, e?.StackTrace), "FATAL");
         }
     }
 }

--- a/TPPCommon/Logging/TPPLogger.cs
+++ b/TPPCommon/Logging/TPPLogger.cs
@@ -76,7 +76,7 @@ namespace TPPCommon.Logging
         /// <param name="e">exception</param>
         public void LogError(string message, Exception e)
         {
-            this.Publisher.Publish(new LogErrorEvent(ApplyPrefix(message), e));
+            this.Publisher.Publish(new LogErrorExceptionEvent(ApplyPrefix(message), e?.Message, e?.StackTrace));
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace TPPCommon.Logging
         /// <param name="e">exception</param>
         public void LogCritical(string message, Exception e)
         {
-            this.Publisher.Publish(new LogCriticalEvent(ApplyPrefix(message), e));
+            this.Publisher.Publish(new LogCriticalExceptionEvent(ApplyPrefix(message), e?.Message, e?.StackTrace));
         }
     }
 }

--- a/TPPCommon/Logging/TPPLogger.cs
+++ b/TPPCommon/Logging/TPPLogger.cs
@@ -9,9 +9,8 @@ namespace TPPCommon.Logging
     /// This class isn't responsible for perform the actual logging, rather it publishes logging
     /// events, to which a logging service can listen.
     /// </summary>
-    public class TPPLogger : ITPPLogger
+    public class TPPLogger : TPPLoggerBase, ITPPLogger
     {
-        private string Prefix = string.Empty;
         private IPublisher Publisher;
 
         public TPPLogger(IPublisher publisher)
@@ -28,45 +27,44 @@ namespace TPPCommon.Logging
             this.Prefix = prefixMessage ?? string.Empty;
         }
 
-        private string ApplyPrefix(string message)
-        {
-            return this.Prefix + message;
-        }
-
         /// <summary>
         /// Log a debug event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogDebug(string message)
+        /// <param name="args">string format args</param>
+        public void LogDebug(string message, params object[] args)
         {
-            this.Publisher.Publish(new LogDebugEvent(ApplyPrefix(message)));
+            this.Publisher.Publish(new LogDebugEvent(this.NormalizeMessage(message, args)));
         }
 
         /// <summary>
         /// Log a general information event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogInfo(string message)
+        /// <param name="args">string format args</param>
+        public void LogInfo(string message, params object[] args)
         {
-            this.Publisher.Publish(new LogInfoEvent(ApplyPrefix(message)));
+            this.Publisher.Publish(new LogInfoEvent(this.NormalizeMessage(message, args)));
         }
 
         /// <summary>
         /// Log a warning event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogWarning(string message)
+        /// <param name="args">string format args</param>
+        public void LogWarning(string message, params object[] args)
         {
-            this.Publisher.Publish(new LogWarningEvent(ApplyPrefix(message)));
+            this.Publisher.Publish(new LogWarningEvent(this.NormalizeMessage(message, args)));
         }
 
         /// <summary>
         /// Log an error event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogError(string message)
+        /// <param name="args">string format args</param>
+        public void LogError(string message, params object[] args)
         {
-            this.Publisher.Publish(new LogErrorEvent(ApplyPrefix(message)));
+            this.Publisher.Publish(new LogErrorEvent(this.NormalizeMessage(message, args)));
         }
 
         /// <summary>
@@ -74,18 +72,20 @@ namespace TPPCommon.Logging
         /// </summary>
         /// <param name="message">log message</param>
         /// <param name="e">exception</param>
-        public void LogError(string message, Exception e)
+        /// <param name="args">string format args</param>
+        public void LogError(string message, Exception e, params object[] args)
         {
-            this.Publisher.Publish(new LogErrorExceptionEvent(ApplyPrefix(message), e?.Message, e?.StackTrace));
+            this.Publisher.Publish(new LogErrorExceptionEvent(this.NormalizeMessage(message, args), e?.Message, e?.StackTrace));
         }
 
         /// <summary>
         /// Log a critical error event.
         /// </summary>
         /// <param name="message">log message</param>
-        public void LogCritical(string message)
+        /// <param name="args">string format args</param>
+        public void LogCritical(string message, params object[] args)
         {
-            this.Publisher.Publish(new LogCriticalEvent(ApplyPrefix(message)));
+            this.Publisher.Publish(new LogCriticalEvent(this.NormalizeMessage(message, args)));
         }
 
         /// <summary>
@@ -93,9 +93,10 @@ namespace TPPCommon.Logging
         /// </summary>
         /// <param name="message">log message</param>
         /// <param name="e">exception</param>
-        public void LogCritical(string message, Exception e)
+        /// <param name="args">string format args</param>
+        public void LogCritical(string message, Exception e, params object[] args)
         {
-            this.Publisher.Publish(new LogCriticalExceptionEvent(ApplyPrefix(message), e?.Message, e?.StackTrace));
+            this.Publisher.Publish(new LogCriticalExceptionEvent(this.NormalizeMessage(message, args), e?.Message, e?.StackTrace));
         }
     }
 }

--- a/TPPCommon/Logging/TPPLogger.cs
+++ b/TPPCommon/Logging/TPPLogger.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using TPPCommon.PubSub;
+using TPPCommon.PubSub.Events;
+
+namespace TPPCommon.Logging
+{
+    /// <summary>
+    /// Class which TPP services directly use to perform logging.
+    /// This class isn't responsible for perform the actual logging, rather it publishes logging
+    /// events, to which a logging service can listen.
+    /// </summary>
+    public class TPPLogger
+    {
+        private string Prefix = string.Empty;
+        private IPublisher Publisher;
+
+        public TPPLogger(IPublisher publisher)
+        {
+            this.Publisher = publisher;
+        }
+
+        /// <summary>
+        /// Specifies a prefix to add to all log messages.
+        /// </summary>
+        /// <param name="prefixMessage">log message prefix</param>
+        public void SetLogPrefix(string prefixMessage)
+        {
+            this.Prefix = prefixMessage ?? string.Empty;
+        }
+
+        private string ApplyPrefix(string message)
+        {
+            return this.Prefix + message;
+        }
+
+        /// <summary>
+        /// Log a debug event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogDebug(string message)
+        {
+            this.Publisher.Publish(new LogDebugEvent(ApplyPrefix(message)));
+        }
+
+        /// <summary>
+        /// Log a general information event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogInfo(string message)
+        {
+            this.Publisher.Publish(new LogInfoEvent(ApplyPrefix(message)));
+        }
+
+        /// <summary>
+        /// Log a warning event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogWarning(string message)
+        {
+            this.Publisher.Publish(new LogWarningEvent(ApplyPrefix(message)));
+        }
+
+        /// <summary>
+        /// Log an error event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogError(string message)
+        {
+            this.Publisher.Publish(new LogErrorEvent(ApplyPrefix(message)));
+        }
+
+        /// <summary>
+        /// Log an error event along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        public void LogError(string message, Exception e)
+        {
+            this.Publisher.Publish(new LogErrorEvent(ApplyPrefix(message), e));
+        }
+
+        /// <summary>
+        /// Log a critical error event.
+        /// </summary>
+        /// <param name="message">log message</param>
+        public void LogCritical(string message)
+        {
+            this.Publisher.Publish(new LogCriticalEvent(ApplyPrefix(message)));
+        }
+
+        /// <summary>
+        /// Log a critical error event along with its exception.
+        /// </summary>
+        /// <param name="message">log message</param>
+        /// <param name="e">exception</param>
+        public void LogCritical(string message, Exception e)
+        {
+            this.Publisher.Publish(new LogCriticalEvent(ApplyPrefix(message), e));
+        }
+    }
+}

--- a/TPPCommon/Logging/TPPLoggerBase.cs
+++ b/TPPCommon/Logging/TPPLoggerBase.cs
@@ -1,0 +1,17 @@
+﻿using System.Globalization;
+
+namespace TPPCommon.Logging
+{
+    /// <summary>
+    /// Base class for TPPLoggers. Handles localization normalization.
+    /// </summary>
+    public abstract class TPPLoggerBase
+    {
+        protected string Prefix = string.Empty;
+
+        protected string NormalizeMessage(string message, params object[] args)
+        {
+            return this.Prefix + string.Format(CultureInfo.InvariantCulture, message, args);
+        }
+    }
+}

--- a/TPPCommon/PubSub/Events/LogEvent.cs
+++ b/TPPCommon/PubSub/Events/LogEvent.cs
@@ -63,21 +63,38 @@ namespace TPPCommon.PubSub.Events
         [DataMember]
         public string Message { get; set; }
 
-        [DataMember]
-        public Exception @Exception { get; set; }
-
-        public LogErrorEvent(string message) : this(message, null)
-        { }
-
-        public LogErrorEvent(string message, Exception e)
+        public LogErrorEvent(string message)
         {
             this.Message = message;
-            this.Exception = e;
         }
     }
 
     /// <summary>
     /// Pub-sub event class for error-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_error_exception")]
+    public class LogErrorExceptionEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        [DataMember]
+        public string ExceptionMessage { get; set; }
+
+        [DataMember]
+        public string StackTrace { get; set; }
+
+        public LogErrorExceptionEvent(string message, string exceptionMessage, string stackTrace)
+        {
+            this.Message = message;
+            this.ExceptionMessage = exceptionMessage;
+            this.StackTrace = stackTrace;
+        }
+    }
+
+    /// <summary>
+    /// Pub-sub event class for critical-level log messages.
     /// </summary>
     [DataContract]
     [Topic("log_critical")]
@@ -86,16 +103,33 @@ namespace TPPCommon.PubSub.Events
         [DataMember]
         public string Message { get; set; }
 
-        [DataMember]
-        public Exception @Exception { get; set; }
-
-        public LogCriticalEvent(string message) : this(message, null)
-        { }
-
-        public LogCriticalEvent(string message, Exception e)
+        public LogCriticalEvent(string message)
         {
             this.Message = message;
-            this.Exception = e;
+        }
+    }
+
+    /// <summary>
+    /// Pub-sub event class for critical-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_critical_exception")]
+    public class LogCriticalExceptionEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        [DataMember]
+        public string ExceptionMessage { get; set; }
+
+        [DataMember]
+        public string StackTrace { get; set; }
+
+        public LogCriticalExceptionEvent(string message, string exceptionMessage, string stackTrace)
+        {
+            this.Message = message;
+            this.ExceptionMessage = exceptionMessage;
+            this.StackTrace = stackTrace;
         }
     }
 }

--- a/TPPCommon/PubSub/Events/LogEvent.cs
+++ b/TPPCommon/PubSub/Events/LogEvent.cs
@@ -1,20 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text;
+﻿using System.Runtime.Serialization;
 
 namespace TPPCommon.PubSub.Events
 {
+    [DataContract]
+    [Topic("log")]
+    public class LogEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+    }
+
     /// <summary>
     /// Pub-sub event class for debug-level log messages.
     /// </summary>
     [DataContract]
     [Topic("log_debug")]
-    public class LogDebugEvent : PubSubEvent
+    public class LogDebugEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         public LogDebugEvent(string message)
         {
             this.Message = message;
@@ -26,11 +28,8 @@ namespace TPPCommon.PubSub.Events
     /// </summary>
     [DataContract]
     [Topic("log_info")]
-    public class LogInfoEvent : PubSubEvent
+    public class LogInfoEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         public LogInfoEvent(string message)
         {
             this.Message = message;
@@ -42,11 +41,8 @@ namespace TPPCommon.PubSub.Events
     /// </summary>
     [DataContract]
     [Topic("log_warning")]
-    public class LogWarningEvent : PubSubEvent
+    public class LogWarningEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         public LogWarningEvent(string message)
         {
             this.Message = message;
@@ -58,11 +54,8 @@ namespace TPPCommon.PubSub.Events
     /// </summary>
     [DataContract]
     [Topic("log_error")]
-    public class LogErrorEvent : PubSubEvent
+    public class LogErrorEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         public LogErrorEvent(string message)
         {
             this.Message = message;
@@ -74,11 +67,8 @@ namespace TPPCommon.PubSub.Events
     /// </summary>
     [DataContract]
     [Topic("log_error_exception")]
-    public class LogErrorExceptionEvent : PubSubEvent
+    public class LogErrorExceptionEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         [DataMember]
         public string ExceptionMessage { get; set; }
 
@@ -98,11 +88,8 @@ namespace TPPCommon.PubSub.Events
     /// </summary>
     [DataContract]
     [Topic("log_critical")]
-    public class LogCriticalEvent : PubSubEvent
+    public class LogCriticalEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         public LogCriticalEvent(string message)
         {
             this.Message = message;
@@ -114,11 +101,8 @@ namespace TPPCommon.PubSub.Events
     /// </summary>
     [DataContract]
     [Topic("log_critical_exception")]
-    public class LogCriticalExceptionEvent : PubSubEvent
+    public class LogCriticalExceptionEvent : LogEvent
     {
-        [DataMember]
-        public string Message { get; set; }
-
         [DataMember]
         public string ExceptionMessage { get; set; }
 

--- a/TPPCommon/PubSub/Events/LogEvent.cs
+++ b/TPPCommon/PubSub/Events/LogEvent.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace TPPCommon.PubSub.Events
+{
+    /// <summary>
+    /// Pub-sub event class for debug-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_debug")]
+    public class LogDebugEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        public LogDebugEvent(string message)
+        {
+            this.Message = message;
+        }
+    }
+
+    /// <summary>
+    /// Pub-sub event class for info-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_info")]
+    public class LogInfoEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        public LogInfoEvent(string message)
+        {
+            this.Message = message;
+        }
+    }
+
+    /// <summary>
+    /// Pub-sub event class for warning-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_warning")]
+    public class LogWarningEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        public LogWarningEvent(string message)
+        {
+            this.Message = message;
+        }
+    }
+
+    /// <summary>
+    /// Pub-sub event class for error-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_error")]
+    public class LogErrorEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        [DataMember]
+        public Exception @Exception { get; set; }
+
+        public LogErrorEvent(string message) : this(message, null)
+        { }
+
+        public LogErrorEvent(string message, Exception e)
+        {
+            this.Message = message;
+            this.Exception = e;
+        }
+    }
+
+    /// <summary>
+    /// Pub-sub event class for error-level log messages.
+    /// </summary>
+    [DataContract]
+    [Topic("log_critical")]
+    public class LogCriticalEvent : PubSubEvent
+    {
+        [DataMember]
+        public string Message { get; set; }
+
+        [DataMember]
+        public Exception @Exception { get; set; }
+
+        public LogCriticalEvent(string message) : this(message, null)
+        { }
+
+        public LogCriticalEvent(string message, Exception e)
+        {
+            this.Message = message;
+            this.Exception = e;
+        }
+    }
+}

--- a/TPPCommon/PubSub/IBroker.cs
+++ b/TPPCommon/PubSub/IBroker.cs
@@ -1,0 +1,10 @@
+﻿namespace TPPCommon.PubSub
+{
+    /// <summary>
+    /// Interface for PubSub intermediary broker.
+    /// </summary>
+    public interface IBroker
+    {
+        void Run();
+    }
+}

--- a/TPPCommon/PubSub/ZMQBroker.cs
+++ b/TPPCommon/PubSub/ZMQBroker.cs
@@ -1,0 +1,30 @@
+﻿using NetMQ;
+using NetMQ.Sockets;
+using System;
+
+namespace TPPCommon.PubSub
+{
+    /// <summary>
+    /// This broker acts as an intermediary for publishers and subscribers.
+    /// This allows seemlessly adding new publishers and subscribers to the pub-sub network.
+    /// 
+    /// See https://netmq.readthedocs.io/en/latest/xpub-xsub/ for more information.
+    /// </summary>
+    public class ZMQBroker : IBroker
+    {
+        public void Run()
+        {
+            using (var xPubSocket = new XPublisherSocket(Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.PublisherPort)))
+            using (var xSubSocket = new XSubscriberSocket(Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.SubscriberPort)))
+            {
+                Console.WriteLine("Intermediary broker started, and waiting for messages");
+
+                // proxy messages between frontend / backend
+                var proxy = new Proxy(xSubSocket, xPubSocket);
+
+                // blocks indefinitely
+                proxy.Start();
+            }
+        }
+    }
+}

--- a/TPPCommon/PubSub/ZMQBroker.cs
+++ b/TPPCommon/PubSub/ZMQBroker.cs
@@ -14,13 +14,13 @@ namespace TPPCommon.PubSub
     {
         public void Run()
         {
-            using (var xPubSocket = new XPublisherSocket(Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.PublisherPort)))
-            using (var xSubSocket = new XSubscriberSocket(Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.SubscriberPort)))
+            using (var xPubSocket = new XPublisherSocket("@" + Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.PublisherPort)))
+            using (var xSubSocket = new XSubscriberSocket("@" + Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.SubscriberPort)))
             {
                 Console.WriteLine("Intermediary broker started, and waiting for messages");
 
                 // proxy messages between frontend / backend
-                var proxy = new Proxy(xSubSocket, xPubSocket);
+                var proxy = new Proxy(xPubSocket, xSubSocket);
 
                 // blocks indefinitely
                 proxy.Start();

--- a/TPPCommon/PubSub/ZMQPublisher.cs
+++ b/TPPCommon/PubSub/ZMQPublisher.cs
@@ -41,7 +41,7 @@ namespace TPPCommon.PubSub
             this.Serializer = serializer;
 
             this.Socket = InitSocket();
-            this.Port = Addresses.PubSubPort;
+            this.Port = Addresses.SubscriberPort;
 
             string addressToBind = Addresses.BuildFullAddress(Addresses.TCPLocalHost, this.Port);
             this.Socket.Bind(addressToBind);

--- a/TPPCommon/PubSub/ZMQPublisher.cs
+++ b/TPPCommon/PubSub/ZMQPublisher.cs
@@ -18,11 +18,6 @@ namespace TPPCommon.PubSub
         private PublisherSocket Socket;
 
         /// <summary>
-        /// Port number to which the publisher is bound.
-        /// </summary>
-        private int Port;
-
-        /// <summary>
         /// Maximum number of events this publisher will queue in memory before potentially dropping events.
         /// ZMQ's default is 1000.
         /// </summary>
@@ -39,12 +34,7 @@ namespace TPPCommon.PubSub
         public ZMQPublisher(IPubSubEventSerializer serializer)
         {
             this.Serializer = serializer;
-
             this.Socket = InitSocket();
-            this.Port = Addresses.SubscriberPort;
-
-            string addressToBind = Addresses.BuildFullAddress(Addresses.TCPLocalHost, this.Port);
-            this.Socket.Bind(addressToBind);
         }
 
         ~ZMQPublisher()
@@ -58,7 +48,8 @@ namespace TPPCommon.PubSub
 
         private PublisherSocket InitSocket()
         {
-            PublisherSocket socket = new PublisherSocket();
+            string addressToBind = ">" + Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.SubscriberPort);
+            PublisherSocket socket = new PublisherSocket(addressToBind);
             socket.Options.SendHighWatermark = ZMQPublisher.SendHighWatermark;
 
             return socket;

--- a/TPPCommon/PubSub/ZMQSubscriber.cs
+++ b/TPPCommon/PubSub/ZMQSubscriber.cs
@@ -19,11 +19,6 @@ namespace TPPCommon.PubSub
         private NetMQPoller Poller;
 
         /// <summary>
-        /// Port number to which the subscriber is connected.
-        /// </summary>
-        private int Port;
-
-        /// <summary>
         /// Maximum number of messages this subscriber will queue in memory before potentially dropping messages.
         /// ZMQ's default is 1000.
         /// </summary>
@@ -47,11 +42,6 @@ namespace TPPCommon.PubSub
             this.Serializer = serializer;
 
             this.Socket = InitSocket();
-            this.Port = Addresses.PublisherPort;
-
-            // Connect socket to publisher.
-            string addressToConnect = Addresses.BuildFullAddress(Addresses.TCPLocalHost, this.Port);
-            this.Socket.Connect(addressToConnect);
 
             // Setup non-blocking polling for subscriber socket.
             this.Poller = new NetMQPoller();
@@ -77,7 +67,8 @@ namespace TPPCommon.PubSub
 
         private SubscriberSocket InitSocket()
         {
-            SubscriberSocket socket = new SubscriberSocket();
+            string addressToConnect = ">" + Addresses.BuildFullAddress(Addresses.TCPLocalHost, Addresses.PublisherPort);
+            SubscriberSocket socket = new SubscriberSocket(addressToConnect);
             socket.Options.SendHighWatermark = ZMQSubscriber.ReceiveHighWatermark;
 
             return socket;

--- a/TPPCommon/PubSub/ZMQSubscriber.cs
+++ b/TPPCommon/PubSub/ZMQSubscriber.cs
@@ -47,7 +47,7 @@ namespace TPPCommon.PubSub
             this.Serializer = serializer;
 
             this.Socket = InitSocket();
-            this.Port = Addresses.PubSubPort;
+            this.Port = Addresses.PublisherPort;
 
             // Connect socket to publisher.
             string addressToConnect = Addresses.BuildFullAddress(Addresses.TCPLocalHost, this.Port);

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -16,10 +16,9 @@ namespace TestClient
             // Setup dependency injection, to hide the pub-sub implementation.
             var serviceCollection = new ServiceCollection()
                 .AddTransient<IPubSubEventSerializer, JSONPubSubEventSerializer>()
-                .AddTransient<ZMQSubscriber>()
                 .AddTransient<ISubscriber, ZMQSubscriber>()
                 .AddTransient<IPublisher, ZMQPublisher>()
-                .AddTransient<TPPLogger>()
+                .AddTransient<ITPPLogger, TPPDebugLogger>()
                 .AddTransient<TestClient>();
             var serviceProvider = serviceCollection.BuildServiceProvider();
 

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 using TPPCommon.Logging;
 using TPPCommon.PubSub;
 using TPPCommon.PubSub.Events;
@@ -9,6 +10,9 @@ namespace TestClient
     {
         static void Main(string[] args)
         {
+            // Give time for PubSubBroker to warm up.
+            Thread.Sleep(2000);
+
             // Setup dependency injection, to hide the pub-sub implementation.
             var serviceCollection = new ServiceCollection()
                 .AddTransient<IPubSubEventSerializer, JSONPubSubEventSerializer>()

--- a/TestClient/TestClient.cs
+++ b/TestClient/TestClient.cs
@@ -14,14 +14,14 @@ namespace TestClient
     {
         private ISubscriber Subscriber;
         private IPublisher Publisher;
-        private TPPLogger Logger;
+        private ITPPLogger Logger;
         private int TotalEventsReceived;
 
-        public TestClient(ISubscriber subscriber, IPublisher publisher)
+        public TestClient(ISubscriber subscriber, IPublisher publisher, ITPPLogger logger)
         {
             this.Subscriber = subscriber;
             this.Publisher = publisher;
-            this.Logger = new TPPLogger(this.Publisher);
+            this.Logger = logger;
             this.TotalEventsReceived = 0;
         }
 

--- a/TestClient/TestClient.cs
+++ b/TestClient/TestClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using TPPCommon.Logging;
 using TPPCommon.PubSub;
 using TPPCommon.PubSub.Events;
 
@@ -12,17 +13,22 @@ namespace TestClient
     class TestClient
     {
         private ISubscriber Subscriber;
+        private IPublisher Publisher;
+        private TPPLogger Logger;
         private int TotalEventsReceived;
 
-        public TestClient(ISubscriber subscriber)
+        public TestClient(ISubscriber subscriber, IPublisher publisher)
         {
             this.Subscriber = subscriber;
+            this.Publisher = publisher;
+            this.Logger = new TPPLogger(this.Publisher);
             this.TotalEventsReceived = 0;
         }
 
         public void Run()
         {
-            Console.WriteLine("Running Subscriber client...");
+            this.Logger.SetLogPrefix("(TestClient) ");
+            this.Logger.LogInfo("Running Subscriber client...");
 
             // Subscribe to the pub-sub topics, and assign event handler functions for each topic.
             this.Subscriber.Subscribe<SongInfoEvent>(OnSongInfoChanged);
@@ -38,15 +44,15 @@ namespace TestClient
         void OnSongInfoChanged(SongInfoEvent @event)
         {
             this.TotalEventsReceived += 1;
-            Console.WriteLine($"Song Info:  Id = {@event.Id}, Title = '{@event.Title}', Artist = '{@event.Artist}'");
-            Console.WriteLine($"Total Events Received: {this.TotalEventsReceived}");
+            this.Logger.LogInfo($"Song Info:  Id = {@event.Id}, Title = '{@event.Title}', Artist = '{@event.Artist}'");
+            this.Logger.LogDebug($"Total Events Received: {this.TotalEventsReceived}");
         }
 
         void OnSongPaused(SongPausedEvent @event)
         {
             this.TotalEventsReceived += 1;
-            Console.WriteLine($"Song was paused!");
-            Console.WriteLine($"Total Events Received: {this.TotalEventsReceived}");
+            this.Logger.LogInfo($"Song was paused!");
+            this.Logger.LogDebug($"Total Events Received: {this.TotalEventsReceived}");
         }
     }
 }

--- a/TestServer/Program.cs
+++ b/TestServer/Program.cs
@@ -11,6 +11,7 @@ namespace TestServer
             // Setup dependency injection, to hide the pub-sub implementation.
             var serviceCollection = new ServiceCollection()
                 .AddTransient<IPublisher, ZMQPublisher>()
+                .AddTransient<ISubscriber, ZMQSubscriber>()
                 .AddTransient<TestServer>()
                 .AddTransient<IPubSubEventSerializer, JSONPubSubEventSerializer>()
                 .AddTransient<ZMQPublisher>();

--- a/TestServer/Program.cs
+++ b/TestServer/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 using TPPCommon.PubSub;
 using TPPCommon.PubSub.Events;
 
@@ -8,6 +9,9 @@ namespace TestServer
     {
         static void Main(string[] args)
         {
+            // Give time for PubSubBroker to warm up.
+            Thread.Sleep(2000);
+
             // Setup dependency injection, to hide the pub-sub implementation.
             var serviceCollection = new ServiceCollection()
                 .AddTransient<IPublisher, ZMQPublisher>()

--- a/TestServer/Program.cs
+++ b/TestServer/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.Threading;
+using TPPCommon.Logging;
 using TPPCommon.PubSub;
 using TPPCommon.PubSub.Events;
 
@@ -16,9 +17,9 @@ namespace TestServer
             var serviceCollection = new ServiceCollection()
                 .AddTransient<IPublisher, ZMQPublisher>()
                 .AddTransient<ISubscriber, ZMQSubscriber>()
-                .AddTransient<TestServer>()
+                .AddTransient<ITPPLogger, TPPDebugLogger>()
                 .AddTransient<IPubSubEventSerializer, JSONPubSubEventSerializer>()
-                .AddTransient<ZMQPublisher>();
+                .AddTransient<TestServer>();
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             // Run server.

--- a/TestServer/TestServer.cs
+++ b/TestServer/TestServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TPPCommon.Logging;
 using TPPCommon.PubSub;
 using TPPCommon.PubSub.Events;
 
@@ -10,15 +11,18 @@ namespace TestServer
     class TestServer
     {
         private IPublisher Publisher;
+        private TPPLogger Logger;
 
         public TestServer(IPublisher publisher)
         {
             this.Publisher = publisher;
+            this.Logger = new TPPLogger(this.Publisher);
         }
 
         public void Run()
         {
-            Console.WriteLine("Running Music Server, Enter keys to publish events...");
+            this.Logger.SetLogPrefix("(TestServer) ");
+            this.Logger.LogInfo("Running Music Server, Enter keys to publish events...");
 
             while (true)
             {
@@ -31,15 +35,17 @@ namespace TestServer
                     break;
                 }
 
+                this.Logger.LogDebug($"The keystroke was {input}");
+
                 // Decide which event to publish.
                 if (input == "A")
                 {
-                    Console.WriteLine($"Sending Song Paused Event...");
+                    this.Logger.LogInfo($"Sending Song Paused Event...");
                     this.Publisher.Publish(new SongPausedEvent());
                 }
                 else
                 {
-                    Console.WriteLine($"Sending Song Info Event...");
+                    this.Logger.LogInfo($"Sending Song Info Event...");
                     SongInfoEvent @event = new SongInfoEvent(10, "Battle Theme", "Game Freak");
                     this.Publisher.Publish(@event);
                 }

--- a/TestServer/TestServer.cs
+++ b/TestServer/TestServer.cs
@@ -11,12 +11,12 @@ namespace TestServer
     class TestServer
     {
         private IPublisher Publisher;
-        private TPPLogger Logger;
+        private ITPPLogger Logger;
 
-        public TestServer(IPublisher publisher)
+        public TestServer(IPublisher publisher, ITPPLogger logger)
         {
             this.Publisher = publisher;
-            this.Logger = new TPPLogger(this.Publisher);
+            this.Logger = logger;
         }
 
         public void Run()

--- a/TppCore.sln
+++ b/TppCore.sln
@@ -11,9 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TPPCommon", "TPPCommon\TPPC
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TPPCommonTest", "TPPCommonTest\TPPCommonTest.csproj", "{EE8F97DE-DC32-46C6-8680-03A91389B41F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPersistence", "TestPersistence\TestPersistence.csproj", "{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestPersistence", "TestPersistence\TestPersistence.csproj", "{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PubSubBroker", "PubSubBroker\PubSubBroker.csproj", "{64EBD83B-D3EC-4F80-AABD-629265317433}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PubSubBroker", "PubSubBroker\PubSubBroker.csproj", "{64EBD83B-D3EC-4F80-AABD-629265317433}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogService", "LogService\LogService.csproj", "{8C2BF055-1035-48FF-B957-BA125189ADB8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +47,10 @@ Global
 		{64EBD83B-D3EC-4F80-AABD-629265317433}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64EBD83B-D3EC-4F80-AABD-629265317433}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{64EBD83B-D3EC-4F80-AABD-629265317433}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C2BF055-1035-48FF-B957-BA125189ADB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C2BF055-1035-48FF-B957-BA125189ADB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C2BF055-1035-48FF-B957-BA125189ADB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C2BF055-1035-48FF-B957-BA125189ADB8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TppCore.sln
+++ b/TppCore.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TPPCommonTest", "TPPCommonT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestPersistence", "TestPersistence\TestPersistence.csproj", "{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PubSubBroker", "PubSubBroker\PubSubBroker.csproj", "{64EBD83B-D3EC-4F80-AABD-629265317433}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F0D2A34-E767-43D5-B918-A4D26A18BFE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64EBD83B-D3EC-4F80-AABD-629265317433}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64EBD83B-D3EC-4F80-AABD-629265317433}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64EBD83B-D3EC-4F80-AABD-629265317433}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64EBD83B-D3EC-4F80-AABD-629265317433}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**This pull request does 2 things:**

1. Create a pub-sub proxy service.
This proxy is necessary to allow an arbitrary number of publishers and subscribers to use the pub-sub network.  Without the proxy, only a single publisher can bind to the pub-sub port at a time.  We didn't notice this before because our test server and client were just a 1-to-1 scenario.  With the proxy, all publishers send their published events to the proxy's publisher port, and all subscribers bind to the proxy's subscriber port.  When the proxy receives published events, it pumps them out to the subscribers.  [Read more about the proxy pattern here.](https://netmq.readthedocs.io/en/latest/xpub-xsub/)

2. Create the first pass of logging infrastructure.
TPP will have many independent processes running simultaneously, but we want all of their logs to be aggregated in a single file.  My first approach was to use log4net's FileAppender that pointed to the same file for every process.  This didn't work well enough because some log messages would be dropped when two processes would try to write to the log file at the same time.  I decided it was simplest and most elegant to create  LogService which uses pub-sub to subscribe to `LogEvent` events.  When it receives a log event, it looks at its error level, and does the appropriate thing with the message.  For now, I have it configured to print all log messages to the console, but it omits the debug-level log messages from the rolling log file on disk.

The result of this pull request means that the `PubSubBroker` project **must always** be run alongside any other services, since it facilitates all pub-sub messaging.