### PR TITLE
Add mock pub sub and chat service stub code

### DIFF
--- a/TPPCommon/Chat/Client/ChatCommandMessage.cs
+++ b/TPPCommon/Chat/Client/ChatCommandMessage.cs
@@ -1,0 +1,14 @@
+namespace TPPCommon.Chat.Client {
+    /// <summary>
+    /// A chat message that is sent from us to a destination.
+    /// Examples of commands include sending a text message to a channel room,
+    /// changing room state, launch a poll.
+    /// </summary>
+    public class ChatCommandMessage
+    {
+        public ChatCommandMessage()
+        {
+
+        }
+    }
+}

--- a/TPPCommon/Chat/Client/ChatMessage.cs
+++ b/TPPCommon/Chat/Client/ChatMessage.cs
@@ -1,0 +1,13 @@
+namespace TPPCommon.Chat.Client {
+    /// <summary>
+    /// A message received from a chat client.
+    /// Messages examples could be text typed by users, room membership changes,
+    /// a poll asking for votes.
+    /// </summary>
+    public class ChatMessage {
+        public ChatMessage()
+        {
+
+        }
+    }
+}

--- a/TPPCommon/Chat/Client/ChatTextMessage.cs
+++ b/TPPCommon/Chat/Client/ChatTextMessage.cs
@@ -1,0 +1,11 @@
+namespace TPPCommon.Chat.Client {
+    /// <summary>
+    /// A chat message that is sent from a user to channel or directly to us.
+    /// </summary>
+    public class ChatTextMessage : ChatMessage {
+        public ChatTextMessage()
+        {
+
+        }
+    }
+}

--- a/TPPCommon/Chat/Client/ConnectionConfig.cs
+++ b/TPPCommon/Chat/Client/ConnectionConfig.cs
@@ -1,0 +1,9 @@
+namespace TPPCommon.Chat.Client
+{
+    /// <summary>
+    /// Configuration details for a chat client to connect to a server
+    /// </summary>
+    public class ConnectionConfig
+    {
+    }
+}

--- a/TPPCommon/Chat/Client/DummyChatClient.cs
+++ b/TPPCommon/Chat/Client/DummyChatClient.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace TPPCommon.Chat.Client {
+    public class DummyChatClient : IChatClient
+    {
+        private int dummyReceiveCounter = 0;
+        private bool _isConnected = false;
+
+        public DummyChatClient()
+        {
+        }
+
+        public async Task ConnectAsync(ConnectionConfig config)
+        {
+            if (dummyReceiveCounter % 2 == 1) {
+                throw new SocketException(1);
+            }
+
+            _isConnected = true;
+            dummyReceiveCounter++;
+            await Task.Delay(1000);
+        }
+
+        public void Disconnect()
+        {
+            _isConnected = false;
+        }
+
+        public bool IsConnected()
+        {
+            return _isConnected;
+        }
+
+        public async Task<ChatMessage> ReceiveMessageAsync()
+        {
+            if (!_isConnected) {
+                throw new InvalidOperationException("Not connected");
+            }
+
+            await Task.Delay(10);
+
+            var message = new ChatMessage();
+            dummyReceiveCounter++;
+
+            return message;
+        }
+
+        public async Task SendMessageAsync(ChatCommandMessage message)
+        {
+            if (!_isConnected) {
+                throw new InvalidOperationException("Not connected");
+            }
+
+            await Task.Delay(50);
+        }
+    }
+}

--- a/TPPCommon/Chat/Client/IChatClient.cs
+++ b/TPPCommon/Chat/Client/IChatClient.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace TPPCommon.Chat.Client {
+    /// <summary>
+    /// A client for connecting to a chat server.
+    /// Example servers include IRC servers, websocket endpoints.
+    /// </summary>
+    public interface IChatClient {
+        Task ConnectAsync(ConnectionConfig config);
+        void Disconnect();
+        bool IsConnected();
+        Task SendMessageAsync(ChatCommandMessage message);
+        Task<ChatMessage> ReceiveMessageAsync();
+    }
+}

--- a/TPPCommon/Chat/Service/BaseChatService.cs
+++ b/TPPCommon/Chat/Service/BaseChatService.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using TPPCommon.Chat;
+using TPPCommon.Configuration;
+using TPPCommon.Logging;
+using TPPCommon.PubSub;
+using TPPCommon.PubSub.Events;
+
+namespace TPPCommon.Chat.Service {
+    /// <summary>
+    /// Chat service for handling, sending, and dispatching messages to PubSub
+    /// and the chat client.
+    /// </summary>
+    public abstract class BaseChatService : TPPService {
+        protected TPPLoggerBase Logger;
+        protected ExponentialBackoffCounter backoff;
+        protected Client.IChatClient ChatClient;
+        protected Client.ConnectionConfig ConnectionConfig;
+        protected abstract string ServiceName { get; }
+
+        protected override string[] ConfigNames
+        {
+            get => new string[] { $"config_{ServiceName}" };
+        }
+        protected override int StartupDelayMilliseconds
+        {
+            get => 0;
+        }
+
+        public BaseChatService(
+                IPublisher publisher,
+                ISubscriber subscriber,
+                ITPPLoggerFactory loggerFactory,
+                IConfigReader configReader) :
+                base (publisher, subscriber, loggerFactory, configReader)
+        {
+            backoff = new ExponentialBackoffCounter();
+        }
+
+        override protected void Initialize()
+        {
+            Logger = LoggerFactory.Create($"chat.{ServiceName}");
+        }
+
+        override protected void Run()
+        {
+            while (true) {
+                Connect().Wait();
+
+                if (!ChatClient.IsConnected())
+                {
+                    continue;
+                }
+
+                ProcessMessagesAsync().Wait();
+
+                Logger.LogInfo("Chat service disconnected");
+                backoff.Increment();
+                backoff.Sleep();
+            }
+        }
+
+        public void InitializeClient() {
+            Initialize();
+        }
+
+        public async Task Connect()
+        {
+            Logger.LogInfo("Chat service connecting");
+
+            try {
+                await ChatClient.ConnectAsync(ConnectionConfig);
+            } catch (SocketException error) {
+                Logger.LogError("Error connecting to chat", error);
+
+                backoff.Increment();
+                await backoff.SleepAsync();
+            }
+
+            Logger.LogInfo("Chat service connected");
+            backoff.Reset();
+        }
+
+        public async Task ProcessMessagesAsync()
+        {
+            Logger.LogDebug("Processing messages");
+
+            var sendTask = SendMessagesAsync();
+            var receiveTask = ReceiveMessagesAsync();
+            Task[] tasks = {sendTask, receiveTask};
+            await Task.WhenAny(tasks);
+
+            ChatClient.Disconnect();
+
+            Logger.LogDebug("Stopped processing messages");
+        }
+
+        public async Task SendMessagesAsync()
+        {
+            Logger.LogDebug("Processing sending messages");
+
+            while (ChatClient.IsConnected()) {
+                // TODO: read messages from a queue
+                await Task.Delay(1000);
+            }
+
+            Logger.LogDebug("Stopped sending messages");
+        }
+
+        public async Task ReceiveMessagesAsync()
+        {
+            Logger.LogDebug("Processing receiving messages");
+
+            while (ChatClient.IsConnected()) {
+                await ReceiveOneMessageAsync();
+            }
+
+            Logger.LogDebug("Stopped receiving messages");
+        }
+
+        public async Task ReceiveOneMessageAsync()
+        {
+            var message = await ChatClient.ReceiveMessageAsync();
+            ChatMessageEvent chatEvent =
+                new ChatMessageEvent(ServiceName, message);
+            Publisher.Publish(chatEvent);
+        }
+    }
+}

--- a/TPPCommon/Chat/Service/DummyChatService.cs
+++ b/TPPCommon/Chat/Service/DummyChatService.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using TPPCommon.Chat;
+using TPPCommon.Configuration;
+using TPPCommon.Logging;
+using TPPCommon.PubSub;
+using TPPCommon.PubSub.Events;
+
+namespace TPPCommon.Chat.Service
+{
+    public class DummyChatService : BaseChatService
+    {
+        protected override string ServiceName
+        {
+            get => "dummy_chat";
+        }
+
+        public DummyChatService(
+                IPublisher publisher,
+                ISubscriber subscriber,
+                ITPPLoggerFactory loggerFactory,
+                IConfigReader configReader) :
+                base (publisher, subscriber, loggerFactory, configReader)
+        {
+            ChatClient = new Client.DummyChatClient();
+            ConnectionConfig = new Client.ConnectionConfig();
+        }
+    }
+}

--- a/TPPCommon/ExponentialBackoffCounter.cs
+++ b/TPPCommon/ExponentialBackoffCounter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+
+namespace TPPCommon
+{
+    /// <summary>
+    /// Counter for retry attempt throttling with exponential backoff.
+    /// </summary>
+    public class ExponentialBackoffCounter {
+        public int MinimumBackoffTime {get; set;} = 1_000;
+        public int MaximumBackoffTime {get; set;} = 300_000;
+        public int CurrentBackoffTime {get; protected set;} = 1_000;
+        public bool UsesJitter {get; set;} = true;
+
+        protected Random Random;
+
+        public ExponentialBackoffCounter() {
+        }
+
+        public void Reset() {
+            CurrentBackoffTime = MinimumBackoffTime;
+        }
+
+        public void Increment() {
+            CurrentBackoffTime *= 2;
+            CurrentBackoffTime = Math.Min(MaximumBackoffTime, CurrentBackoffTime);
+        }
+
+        public async Task SleepAsync() {
+            int jitter = UsesJitter ? this.Random.Next(1000) : 0;
+
+            await Task.Delay(CurrentBackoffTime + jitter);
+        }
+
+        public void Sleep() {
+            SleepAsync().Wait();
+        }
+    }
+}

--- a/TPPCommon/PubSub/Events/ChatMessageEvent.cs
+++ b/TPPCommon/PubSub/Events/ChatMessageEvent.cs
@@ -1,0 +1,24 @@
+using System.Runtime.Serialization;
+using TPPCommon.Chat.Client;
+
+namespace TPPCommon.PubSub.Events
+{
+    /// <summary>
+    /// Event for a chat message received from a chat service.
+    /// </summary>
+    [DataContract]
+    [Topic("chat")]
+    public class ChatMessageEvent : PubSubEvent
+    {
+        [DataMember]
+        public string ServiceName { get; set; }
+
+        [DataMember]
+        public ChatMessage Message { get; set; }
+
+        public ChatMessageEvent(string serviceName, ChatMessage message) {
+            ServiceName = serviceName;
+            Message = message;
+        }
+    }
+}

--- a/TPPCommonTest/BaseServiceTest.cs
+++ b/TPPCommonTest/BaseServiceTest.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using TPPCommon;
+using TPPCommon.Configuration;
+using TPPCommon.Logging;
+using TPPCommon.PubSub;
+using Xunit.Abstractions;
+
+namespace TPPCommonTest {
+    public class BaseServiceTest
+    {
+        protected readonly ITestOutputHelper Output;
+        protected IServiceCollection ServiceCollection;
+        protected IServiceProvider ServiceProvider;
+
+        public BaseServiceTest(ITestOutputHelper output)
+        {
+            this.Output = output;
+
+            BuildServiceCollection();
+            ServiceProvider = ServiceCollection.BuildServiceProvider();
+        }
+
+        protected virtual void BuildServiceCollection()
+        {
+            ServiceCollection = new ServiceCollection()
+                .AddScoped<IPublisher, MockPubSub>()
+                .AddScoped<ISubscriber, MockPubSub>()
+                .AddTransient<ITPPLoggerFactory>(
+                    s => new MockLoggerFactory(s.GetService<IPublisher>(), Output))
+                .AddTransient<IConfigReader, MockConfigReader>();
+        }
+    }
+}

--- a/TPPCommonTest/DummyChatServiceTest.cs
+++ b/TPPCommonTest/DummyChatServiceTest.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using TPPCommon.Chat.Service;
+using TPPCommon.PubSub;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TPPCommonTest
+{
+    public class DummyChatServiceTest : BaseServiceTest
+    {
+        public DummyChatServiceTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void BuildServiceCollection() {
+            base.BuildServiceCollection();
+
+            ServiceCollection.AddScoped<DummyChatService>();
+        }
+
+        [Fact]
+        public async Task TestReceiveMessage()
+        {
+            DummyChatService service = ServiceProvider.GetService<DummyChatService>();
+            MockPubSub pubSub = (MockPubSub) ServiceProvider.GetService<IPublisher>();
+
+            service.InitializeClient();
+
+            await service.Connect();
+            await service.ReceiveOneMessageAsync();
+
+            Assert.NotEmpty(pubSub.events);
+        }
+    }
+}

--- a/TPPCommonTest/ExponentialBackoffCounterTest.cs
+++ b/TPPCommonTest/ExponentialBackoffCounterTest.cs
@@ -1,0 +1,35 @@
+using TPPCommon;
+using Xunit;
+
+namespace TPPCommonTest
+{
+    public class ExponentialBackoffCounterTest
+    {
+        [Fact]
+        public void TestIncrementAndReset()
+        {
+            var counter = new ExponentialBackoffCounter();
+
+            Assert.Equal(1_000, counter.CurrentBackoffTime);
+
+            counter.Increment();
+            Assert.Equal(2_000, counter.CurrentBackoffTime);
+
+            counter.Reset();
+            Assert.Equal(1_000, counter.CurrentBackoffTime);
+        }
+
+        [Fact]
+        public void TestMaximumTime()
+        {
+            var counter = new ExponentialBackoffCounter();
+
+            for (var index = 0; index < 1000; index++)
+            {
+                counter.Increment();
+            }
+
+            Assert.Equal(300_000, counter.CurrentBackoffTime);
+        }
+    }
+}

--- a/TPPCommonTest/MockConfigReader.cs
+++ b/TPPCommonTest/MockConfigReader.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using TPPCommon.Configuration;
+
+namespace TPPCommonTest
+{
+    public class MockConfigReader : IConfigReader
+    {
+        public MockConfigReader()
+        {
+        }
+
+        public T ReadConfig<T>(IDictionary<string, string> configOverrides, string configFileOverride, params string[] configNames)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/TPPCommonTest/MockLogger.cs
+++ b/TPPCommonTest/MockLogger.cs
@@ -1,0 +1,53 @@
+using System;
+using TPPCommon.Logging;
+using TPPCommon.PubSub;
+using Xunit.Abstractions;
+
+namespace TPPCommonTest
+{
+    public class MockLogger : TPPLoggerBase
+    {
+        protected readonly ITestOutputHelper Output;
+
+        public MockLogger(IPublisher publisher, string identifier,
+                ITestOutputHelper output) : base(publisher, identifier)
+        {
+            this.Output = output;
+        }
+
+        public override void LogCritical(string message, params object[] args)
+        {
+            Output.WriteLine(message + args);
+        }
+
+        public override void LogCritical(string message, Exception e, params object[] args)
+        {
+            Output.WriteLine(message + e + args);
+        }
+
+        public override void LogDebug(string message, params object[] args)
+        {
+            Output.WriteLine(message + args);
+        }
+
+        public override void LogError(string message, params object[] args)
+        {
+            Output.WriteLine(message + args);
+        }
+
+        public override void LogError(string message, Exception e, params object[] args)
+        {
+            Output.WriteLine(message + e + args);
+        }
+
+        public override void LogInfo(string message, params object[] args)
+        {
+            Output.WriteLine(message + args);
+        }
+
+        public override void LogWarning(string message, params object[] args)
+        {
+            Output.WriteLine(message + args);
+        }
+    }
+}

--- a/TPPCommonTest/MockLoggerFactory.cs
+++ b/TPPCommonTest/MockLoggerFactory.cs
@@ -1,0 +1,23 @@
+using TPPCommon.Logging;
+using TPPCommon.PubSub;
+using Xunit.Abstractions;
+
+namespace TPPCommonTest
+{
+    public class MockLoggerFactory : ITPPLoggerFactory
+    {
+        protected IPublisher Publisher;
+        protected ITestOutputHelper Output;
+
+        public MockLoggerFactory(IPublisher publisher, ITestOutputHelper output)
+        {
+            this.Publisher = publisher;
+            this.Output = output;
+        }
+
+        public TPPLoggerBase Create(string identifier)
+        {
+            return new MockLogger(Publisher, identifier, Output);
+        }
+    }
+}

--- a/TPPCommonTest/MockPubSub.cs
+++ b/TPPCommonTest/MockPubSub.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using TPPCommon.PubSub;
+using TPPCommon.PubSub.Events;
+
+namespace TPPCommonTest {
+    public class MockPubSub : ISubscriber, IPublisher
+    {
+        public List<PubSubEvent> events;
+
+        public MockPubSub()
+        {
+            events = new List<PubSubEvent>();
+        }
+
+        public void Publish(PubSubEvent @event)
+        {
+            events.Add(@event);
+        }
+
+        public void Subscribe<T>(PubSubEventHandler<T> handler) where T : PubSubEvent
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/TPPCommonTest/TPPCommonTest.csproj
+++ b/TPPCommonTest/TPPCommonTest.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
I was thinking that the chat service should be in two parts internally. `Chat.Client` is intended for code that touches the network so they could be mocked.`Chat.Service` is intended for code that interacts with pub sub. I'm not sure about the design of `TPPService` because it encapsulates everything into a `Run` method.