### PR TITLE
remove default color assignment

### DIFF
--- a/Persistence.MongoDB/Repos/UserRepo.cs
+++ b/Persistence.MongoDB/Repos/UserRepo.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Linq;
+using System;
 using System.Threading.Tasks;
-using Microsoft.VisualBasic;
 using Models;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
@@ -53,32 +51,6 @@ namespace Persistence.MongoDB.Repos
             });
         }
 
-        private static readonly (string, string)[] DefaultTwitchColors =
-        {
-            ("Red", "ff0000"),
-            ("Blue", "0000ff"),
-            ("Green", "00ff00"),
-            ("FireBrick", "b22222"),
-            ("Coral", "ff7f50"),
-            ("YellowGreen", "9acd32"),
-            ("OrangeRed", "ff4500"),
-            ("SeaGreen", "2e8b57"),
-            ("GoldenRod", "daa520"),
-            ("Chocolate", "d2691e"),
-            ("CadetBlue", "5f9ea0"),
-            ("DodgerBlue", "1e90ff"),
-            ("HotPink", "ff69b4"),
-            ("BlueViolet", "8a2be2"),
-            ("SpringGreen", "00ff7f"),
-        };
-
-        private static string GetDefaultColor(string simpleName)
-        {
-            // ported from old core, no idea if this is still correct
-            int n = Strings.Asc(simpleName.First()) + Strings.Asc(simpleName.Last());
-            return DefaultTwitchColors[n % DefaultTwitchColors.Length].Item2;
-        }
-
         public async Task<User> RecordUser(UserInfo userInfo)
         {
             var update = Builders<User>.Update
@@ -107,7 +79,7 @@ namespace Persistence.MongoDB.Repos
                 name: userInfo.SimpleName,
                 twitchDisplayName: userInfo.TwitchDisplayName,
                 simpleName: userInfo.SimpleName,
-                color: userInfo.Color ?? GetDefaultColor(userInfo.SimpleName),
+                color: userInfo.Color,
                 firstActiveAt: userInfo.UpdatedAt,
                 lastActiveAt: userInfo.UpdatedAt,
                 lastMessageAt: userInfo.FromMessage ? userInfo.UpdatedAt : (DateTime?) null,

--- a/Persistence/Models/User.cs
+++ b/Persistence/Models/User.cs
@@ -31,7 +31,7 @@ namespace Models
         /// </summary>
         public string SimpleName { get; private set; }
 
-        public string Color { get; private set; }
+        public string? Color { get; private set; }
 
         public DateTime FirstActiveAt { get; private set; }
         public DateTime LastActiveAt { get; private set; }
@@ -71,7 +71,7 @@ namespace Models
             string name,
             string twitchDisplayName,
             string simpleName,
-            string color,
+            string? color,
             DateTime firstActiveAt,
             DateTime lastActiveAt,
             DateTime? lastMessageAt,


### PR DESCRIPTION
since the default color is computed, it really shouldn't be persisted. especially since the current code is likely wrong, and the way it was done now gives no chances of retroactively fixing it