### PR TITLE
remove flavor data from PkmnSpecies

### DIFF
--- a/ArgsParsing.Tests/TypeParsersTest.cs
+++ b/ArgsParsing.Tests/TypeParsersTest.cs
@@ -148,8 +148,8 @@ namespace ArgsParsing.Tests
             const string speciesId = "79317";
             const string speciesName = "Uniquamon";
             var argsParser = new ArgsParser();
-            // register pokedex names before instantiating the args parser!
-            PkmnSpecies.RegisterPokedexData(speciesId, speciesName, ImmutableDictionary<string, string>.Empty);
+            // register pokemon names before instantiating the args parser!
+            PkmnSpecies.RegisterName(speciesId, speciesName);
             argsParser.AddArgumentParser(new PkmnSpeciesParser());
 
             PkmnSpecies resultById = await argsParser.Parse<PkmnSpecies>(args: ImmutableList.Create("#" + speciesId));

--- a/ArgsParsing/TypeParsers/PkmnSpeciesParser.cs
+++ b/ArgsParsing/TypeParsers/PkmnSpeciesParser.cs
@@ -10,7 +10,7 @@ namespace ArgsParsing.TypeParsers
     /// A parser that recognizes a pokemon species, either by name or by a #-prefixed species id.
     /// Note that this class builds a name lookup at construction,
     /// so make sure all pokemon species names are set up before instantiating this parser.
-    /// For details on that, see <see cref="PkmnSpecies.RegisterPokedexData"/>.
+    /// For details on that, see <see cref="PkmnSpecies.RegisterName"/>.
     /// </summary>
     public class PkmnSpeciesParser : BaseArgumentParser<PkmnSpecies>
     {
@@ -46,7 +46,7 @@ namespace ArgsParsing.TypeParsers
                 }
             }
             string speciesId = args[0].Substring(startIndex: 1);
-            PkmnSpecies? species = PkmnSpecies.OfIdWithPokedexData(speciesId.TrimStart('0'));
+            PkmnSpecies? species = PkmnSpecies.OfIdWithKnownName(speciesId.TrimStart('0'));
             return Task.FromResult(species == null
                 ? ArgsParseResult<PkmnSpecies>.Failure($"did not recognize species '{args[0]}'",
                     ErrorRelevanceConfidence.Likely)

--- a/Common.Tests/PkmnSpeciesTest.cs
+++ b/Common.Tests/PkmnSpeciesTest.cs
@@ -18,23 +18,23 @@ namespace Common.Tests
         }
 
         [Test]
-        public void TestPokedexData()
+        public void TestPokemonNames()
         {
-            PkmnSpecies.RegisterPokedexData("1", "Bulbasaur", new Dictionary<string, string>());
-            PkmnSpecies.RegisterPokedexData("16", "Pidgey", new Dictionary<string, string>());
+            PkmnSpecies.RegisterName("1", "Bulbasaur");
+            PkmnSpecies.RegisterName("16", "Pidgey");
 
             Assert.AreEqual("Bulbasaur", PkmnSpecies.OfId("1").Name);
             Assert.AreEqual("Pidgey", PkmnSpecies.OfId("16").Name);
             Assert.AreEqual("???", PkmnSpecies.OfId("123").Name);
-            Assert.IsNotNull(PkmnSpecies.OfIdWithPokedexData("1"));
-            Assert.IsNotNull(PkmnSpecies.OfIdWithPokedexData("16"));
-            Assert.IsNull(PkmnSpecies.OfIdWithPokedexData("123"));
+            Assert.IsNotNull(PkmnSpecies.OfIdWithKnownName("1"));
+            Assert.IsNotNull(PkmnSpecies.OfIdWithKnownName("16"));
+            Assert.IsNull(PkmnSpecies.OfIdWithKnownName("123"));
 
-            PkmnSpecies.ClearPokedexData();
+            PkmnSpecies.ClearNames();
 
-            Assert.IsNull(PkmnSpecies.OfIdWithPokedexData("1"));
-            Assert.IsNull(PkmnSpecies.OfIdWithPokedexData("16"));
-            Assert.IsNull(PkmnSpecies.OfIdWithPokedexData("123"));
+            Assert.IsNull(PkmnSpecies.OfIdWithKnownName("1"));
+            Assert.IsNull(PkmnSpecies.OfIdWithKnownName("16"));
+            Assert.IsNull(PkmnSpecies.OfIdWithKnownName("123"));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace Common.Tests
         {
             PkmnSpecies instance1 = PkmnSpecies.OfId("16");
             string name1 = instance1.Name;
-            PkmnSpecies.RegisterPokedexData("16", "Pidgey", new Dictionary<string, string>());
+            PkmnSpecies.RegisterName("16", "Pidgey");
             PkmnSpecies instance2 = PkmnSpecies.OfId("16");
             string name2 = instance2.Name;
 


### PR DESCRIPTION
The species class is intended to be an always applicable replacement for passing around raw species identifiers.
Putting more than just the name in it feels like trying to do too much at once.
Later on, there will certainly be more pokedex data, and no later than then would it become obvious that such data should be handled externally to this class.