### PR TITLE
fix unstable test TestLogSlowCommand

### DIFF
--- a/Core.Tests/Commands/CommandProcessorTest.cs
+++ b/Core.Tests/Commands/CommandProcessorTest.cs
@@ -39,7 +39,7 @@ namespace Core.Tests.Commands
             var commandProcessor = new CommandProcessor(loggerMock.Object, new ArgsParser());
             commandProcessor.InstallCommand(new Command("slow", async context =>
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(50));
+                await Task.Delay(TimeSpan.FromMilliseconds(300));
                 return new CommandResult();
             }));
 

--- a/Core.Tests/Commands/MockLoggerExtensions.cs
+++ b/Core.Tests/Commands/MockLoggerExtensions.cs
@@ -46,7 +46,7 @@ namespace Core.Tests.Commands
             loggerMock.Verify(l => l.Log(
                     level,
                     It.IsAny<EventId>(),
-                    It.Is<object>(o => o != null && o.ToString() != null && messageRegex.Match(o.ToString()).Success),
+                    It.Is<object>(o => messageRegex.Match(o.ToString()).Success),
                     It.Is<Exception>(e => exception == null
                                           || e.GetType() == exception.GetType() && e.Message == exception.Message),
                     (Func<object, Exception, string>)It.IsAny<object>()


### PR DESCRIPTION
My original fix, adding null checks there, was completely wrong.
~Turns out this issue occurs every time it tried to verify a log call
but there was none. I still don't know why _that_ happens,
but at least adjusting the sleep in the test seems to reliably fix the issue.~
It was a timing issue, and a bug in Moq caused a NullReferenceException
instead of correctly stating that there were no invocations.