### PR TITLE
fix nullable warning in EnumToStringUsingTranslationMappingSerializer

### DIFF
--- a/Persistence.MongoDB/Serializers/EnumToStringUsingTranslationMappingSerializer.cs
+++ b/Persistence.MongoDB/Serializers/EnumToStringUsingTranslationMappingSerializer.cs
@@ -43,7 +43,7 @@ namespace Persistence.MongoDB.Serializers
         public override T Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
         {
             string valueString = context.Reader.ReadString();
-            if (!_translationBack.TryGetValue(valueString, out T value))
+            if (!_translationBack.TryGetValue(valueString, out T? value))
             {
                 throw new InvalidOperationException(
                     $"encountered unknown enum string value '{valueString}' in db for enum '{typeof(T)}'");


### PR DESCRIPTION
`TryGetValue` sets its out variable to null when the return value is false.
But since that branch does not use the value and throws an exception,
it is non-nullable afterwards.