### PR TITLE
decrease max delay for reconnecting to 30s

### DIFF
--- a/Core/Chat/TwitchChat.cs
+++ b/Core/Chat/TwitchChat.cs
@@ -132,7 +132,7 @@ namespace Core.Chat
         private async Task CheckConnectivityWorker(CancellationToken cancellationToken)
         {
             TimeSpan minDelay = TimeSpan.FromSeconds(3);
-            TimeSpan maxDelay = TimeSpan.FromMinutes(10);
+            TimeSpan maxDelay = TimeSpan.FromSeconds(30);
             TimeSpan delay = minDelay;
             while (!cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
we don't want to wait unnecessarily long until twitch chat is reachable again