### PR TITLE
ArgsParsing: replace int parser with sign specific variants

### DIFF
--- a/TPP.ArgsParsing.Tests/ArgsParserTest.cs
+++ b/TPP.ArgsParsing.Tests/ArgsParserTest.cs
@@ -12,10 +12,10 @@ namespace TPP.ArgsParsing.Tests
         public void TestTooFewArguments()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new NonnegativeIntParser());
+            argsParser.AddArgumentParser(new NonNegativeIntParser());
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<NonnegativeInt, NonnegativeInt>(args: ImmutableList.Create("123")));
+                .Parse<NonNegativeInt, NonNegativeInt>(args: ImmutableList.Create("123")));
             Assert.AreEqual("too few arguments", ex.Message);
         }
 
@@ -23,10 +23,10 @@ namespace TPP.ArgsParsing.Tests
         public void TestTooManyArguments()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new NonnegativeIntParser());
+            argsParser.AddArgumentParser(new NonNegativeIntParser());
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<NonnegativeInt>(args: ImmutableList.Create("123", "234")));
+                .Parse<NonNegativeInt>(args: ImmutableList.Create("123", "234")));
             Assert.AreEqual("too many arguments", ex.Message);
         }
 
@@ -38,11 +38,11 @@ namespace TPP.ArgsParsing.Tests
         public void TestErrorMessageFromRelevantSuccess()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new NonnegativeIntParser());
+            argsParser.AddArgumentParser(new NonNegativeIntParser());
             argsParser.AddArgumentParser(new OptionalParser(argsParser));
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<Optional<NonnegativeInt>>(args: ImmutableList.Create("abc")));
+                .Parse<Optional<NonNegativeInt>>(args: ImmutableList.Create("abc")));
             Assert.AreNotEqual("too many arguments", ex.Message);
             Assert.AreEqual("did not recognize 'abc' as a number", ex.Message);
         }
@@ -56,13 +56,13 @@ namespace TPP.ArgsParsing.Tests
         public void TestErrorMessageFromDeeplyNestedFailure()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new NonnegativeIntParser());
+            argsParser.AddArgumentParser(new NonNegativeIntParser());
             argsParser.AddArgumentParser(new InstantParser());
             argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
             argsParser.AddArgumentParser(new OptionalParser(argsParser));
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<AnyOrder<Optional<NonnegativeInt>, Optional<Instant>>>(args: ImmutableList.Create("X", "Y")));
+                .Parse<AnyOrder<Optional<NonNegativeInt>, Optional<Instant>>>(args: ImmutableList.Create("X", "Y")));
             Assert.AreNotEqual("too many arguments", ex.Message);
             Assert.AreEqual("did not recognize 'X' as a number, or did not recognize 'X' as a UTC-instant", ex.Message);
             Assert.AreEqual(new[]
@@ -84,11 +84,11 @@ namespace TPP.ArgsParsing.Tests
         public void TestNoDuplicateErrorMessages()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new NonnegativeIntParser());
+            argsParser.AddArgumentParser(new NonNegativeIntParser());
             argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<AnyOrder<NonnegativeInt, NonnegativeInt>>(ImmutableList.Create("1", "x")));
+                .Parse<AnyOrder<NonNegativeInt, NonNegativeInt>>(ImmutableList.Create("1", "x")));
             Assert.AreEqual("did not recognize 'x' as a number", ex.Message);
             // this is how it used to be:
             Assert.AreNotEqual("did not recognize 'x' as a number, or did not recognize 'x' as a number", ex.Message);

--- a/TPP.ArgsParsing.Tests/ArgsParserTest.cs
+++ b/TPP.ArgsParsing.Tests/ArgsParserTest.cs
@@ -12,10 +12,10 @@ namespace TPP.ArgsParsing.Tests
         public void TestTooFewArguments()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new NonnegativeIntParser());
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<int, int>(args: ImmutableList.Create("123")));
+                .Parse<NonnegativeInt, NonnegativeInt>(args: ImmutableList.Create("123")));
             Assert.AreEqual("too few arguments", ex.Message);
         }
 
@@ -23,10 +23,10 @@ namespace TPP.ArgsParsing.Tests
         public void TestTooManyArguments()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new NonnegativeIntParser());
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<int>(args: ImmutableList.Create("123", "234")));
+                .Parse<NonnegativeInt>(args: ImmutableList.Create("123", "234")));
             Assert.AreEqual("too many arguments", ex.Message);
         }
 
@@ -38,11 +38,11 @@ namespace TPP.ArgsParsing.Tests
         public void TestErrorMessageFromRelevantSuccess()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new NonnegativeIntParser());
             argsParser.AddArgumentParser(new OptionalParser(argsParser));
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<Optional<int>>(args: ImmutableList.Create("abc")));
+                .Parse<Optional<NonnegativeInt>>(args: ImmutableList.Create("abc")));
             Assert.AreNotEqual("too many arguments", ex.Message);
             Assert.AreEqual("did not recognize 'abc' as a number", ex.Message);
         }
@@ -56,13 +56,13 @@ namespace TPP.ArgsParsing.Tests
         public void TestErrorMessageFromDeeplyNestedFailure()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new NonnegativeIntParser());
             argsParser.AddArgumentParser(new InstantParser());
             argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
             argsParser.AddArgumentParser(new OptionalParser(argsParser));
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<AnyOrder<Optional<int>, Optional<Instant>>>(args: ImmutableList.Create("X", "Y")));
+                .Parse<AnyOrder<Optional<NonnegativeInt>, Optional<Instant>>>(args: ImmutableList.Create("X", "Y")));
             Assert.AreNotEqual("too many arguments", ex.Message);
             Assert.AreEqual("did not recognize 'X' as a number, or did not recognize 'X' as a UTC-instant", ex.Message);
             Assert.AreEqual(new[]
@@ -84,11 +84,11 @@ namespace TPP.ArgsParsing.Tests
         public void TestNoDuplicateErrorMessages()
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new NonnegativeIntParser());
             argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<AnyOrder<int, int>>(ImmutableList.Create("1", "x")));
+                .Parse<AnyOrder<NonnegativeInt, NonnegativeInt>>(ImmutableList.Create("1", "x")));
             Assert.AreEqual("did not recognize 'x' as a number", ex.Message);
             // this is how it used to be:
             Assert.AreNotEqual("did not recognize 'x' as a number, or did not recognize 'x' as a number", ex.Message);

--- a/TPP.ArgsParsing.Tests/TypeParsersTest.cs
+++ b/TPP.ArgsParsing.Tests/TypeParsersTest.cs
@@ -22,19 +22,19 @@ namespace TPP.ArgsParsing.Tests
             var argsParser = new ArgsParser();
             argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
             argsParser.AddArgumentParser(new StringParser());
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new SignedIntParser());
 
             var args1 = ImmutableList.Create("123", "foo");
             var args2 = ImmutableList.Create("foo", "123");
-            (int int1, string string1) = await argsParser.Parse<AnyOrder<int, string>>(args1);
-            (int int2, string string2) = await argsParser.Parse<AnyOrder<int, string>>(args2);
-            Assert.AreEqual(123, int1);
-            Assert.AreEqual(123, int2);
+            (SignedInt int1, string string1) = await argsParser.Parse<AnyOrder<SignedInt, string>>(args1);
+            (SignedInt int2, string string2) = await argsParser.Parse<AnyOrder<SignedInt, string>>(args2);
+            Assert.AreEqual(123, (int)int1);
+            Assert.AreEqual(123, (int)int2);
             Assert.AreEqual("foo", string1);
             Assert.AreEqual("foo", string2);
 
             var ex = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<AnyOrder<int, string>>(ImmutableList.Create("foo", "bar")));
+                .Parse<AnyOrder<SignedInt, string>>(ImmutableList.Create("foo", "bar")));
             Assert.AreEqual(2, ex.Failures.Count);
             Assert.AreEqual("did not recognize 'foo' as a number, or did not recognize 'bar' as a number", ex.Message);
         }
@@ -45,12 +45,12 @@ namespace TPP.ArgsParsing.Tests
             var argsParser = new ArgsParser();
             argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
             argsParser.AddArgumentParser(new OptionalParser(argsParser));
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new SignedIntParser());
             argsParser.AddArgumentParser(new StringParser());
 
             // this used to cause a stack overflow in the any order parser
-            (Optional<int> optionalInt, Optional<string> optionalString) = await argsParser
-                .Parse<AnyOrder<Optional<int>, Optional<string>>>(ImmutableList<string>.Empty);
+            (Optional<SignedInt> optionalInt, Optional<string> optionalString) = await argsParser
+                .Parse<AnyOrder<Optional<SignedInt>, Optional<string>>>(ImmutableList<string>.Empty);
             Assert.False(optionalInt.IsPresent);
             Assert.False(optionalString.IsPresent);
         }
@@ -109,25 +109,27 @@ namespace TPP.ArgsParsing.Tests
             var argsParser = new ArgsParser();
             argsParser.AddArgumentParser(new OneOfParser(argsParser));
             argsParser.AddArgumentParser(new StringParser());
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new SignedIntParser());
             argsParser.AddArgumentParser(new InstantParser());
 
-            OneOf<int, string> result1 = await argsParser.Parse<OneOf<int, string>>(ImmutableList.Create("123"));
-            OneOf<int, string> result2 = await argsParser.Parse<OneOf<int, string>>(ImmutableList.Create("foo"));
+            OneOf<SignedInt, string> result1 =
+                await argsParser.Parse<OneOf<SignedInt, string>>(ImmutableList.Create("123"));
+            OneOf<SignedInt, string> result2 =
+                await argsParser.Parse<OneOf<SignedInt, string>>(ImmutableList.Create("foo"));
             Assert.IsTrue(result1.Item1.IsPresent);
             Assert.IsFalse(result1.Item2.IsPresent);
-            Assert.AreEqual(123, result1.Item1.Value);
+            Assert.AreEqual(123, (int)result1.Item1.Value);
             Assert.IsFalse(result2.Item1.IsPresent);
             Assert.IsTrue(result2.Item2.IsPresent);
             Assert.AreEqual("foo", result2.Item2.Value);
 
             var exUnrecognized = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<OneOf<int, Instant>>(ImmutableList.Create("foo")));
+                .Parse<OneOf<SignedInt, Instant>>(ImmutableList.Create("foo")));
             Assert.AreEqual(2, exUnrecognized.Failures.Count);
             const string errorText = "did not recognize 'foo' as a number, or did not recognize 'foo' as a UTC-instant";
             Assert.AreEqual(errorText, exUnrecognized.Message);
             var exTooManyArgs = Assert.ThrowsAsync<ArgsParseFailure>(() => argsParser
-                .Parse<OneOf<int, int>>(ImmutableList.Create("123", "234")));
+                .Parse<OneOf<SignedInt, SignedInt>>(ImmutableList.Create("123", "234")));
             Assert.AreEqual("too many arguments", exTooManyArgs.Message);
         }
 
@@ -137,14 +139,14 @@ namespace TPP.ArgsParsing.Tests
             var argsParser = new ArgsParser();
             argsParser.AddArgumentParser(new OptionalParser(argsParser));
             argsParser.AddArgumentParser(new StringParser());
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new SignedIntParser());
 
-            var result1 = await argsParser.Parse<Optional<int>>(args: ImmutableList.Create("123"));
-            var result2 = await argsParser.Parse<Optional<int>>(args: ImmutableList<string>.Empty);
-            (Optional<int> result3, string _) = await argsParser
-                .Parse<Optional<int>, string>(args: ImmutableList.Create("foo"));
+            var result1 = await argsParser.Parse<Optional<SignedInt>>(args: ImmutableList.Create("123"));
+            var result2 = await argsParser.Parse<Optional<SignedInt>>(args: ImmutableList<string>.Empty);
+            (Optional<SignedInt> result3, string _) = await argsParser
+                .Parse<Optional<SignedInt>, string>(args: ImmutableList.Create("foo"));
             Assert.IsTrue(result1.IsPresent);
-            Assert.AreEqual(123, result1.Value);
+            Assert.AreEqual(123, (int)result1.Value);
             Assert.IsFalse(result2.IsPresent);
             Assert.IsFalse(result3.IsPresent);
         }

--- a/TPP.ArgsParsing/TypeParsers/IntParser.cs
+++ b/TPP.ArgsParsing/TypeParsers/IntParser.cs
@@ -59,9 +59,9 @@ namespace TPP.ArgsParsing.TypeParsers
         }
     }
 
-    public class NonnegativeIntParser : IntParser<NonnegativeInt>
+    public class NonNegativeIntParser : IntParser<NonNegativeInt>
     {
-        public NonnegativeIntParser() : base(0, int.MaxValue)
+        public NonNegativeIntParser() : base(0, int.MaxValue)
         {
         }
     }

--- a/TPP.ArgsParsing/TypeParsers/IntParser.cs
+++ b/TPP.ArgsParsing/TypeParsers/IntParser.cs
@@ -2,24 +2,25 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using TPP.ArgsParsing.Types;
 
 namespace TPP.ArgsParsing.TypeParsers
 {
     /// <summary>
     /// A parser capable of parsing numbers.
     /// </summary>
-    public class IntParser : BaseArgumentParser<int>
+    public abstract class IntParser<T> : BaseArgumentParser<T> where T : ImplicitNumber, new()
     {
         private readonly int _minValue;
         private readonly int _maxValue;
 
-        public IntParser(int minValue = int.MinValue, int maxValue = int.MaxValue)
+        protected IntParser(int minValue, int maxValue)
         {
             _minValue = minValue;
             _maxValue = maxValue;
         }
 
-        public override Task<ArgsParseResult<int>> Parse(IImmutableList<string> args, Type[] genericTypes)
+        public override Task<ArgsParseResult<T>> Parse(IImmutableList<string> args, Type[] genericTypes)
         {
             string str = args[0];
             try
@@ -27,26 +28,48 @@ namespace TPP.ArgsParsing.TypeParsers
                 int number = int.Parse(str);
                 if (number < _minValue)
                 {
-                    return Task.FromResult(ArgsParseResult<int>.Failure(
+                    return Task.FromResult(ArgsParseResult<T>.Failure(
                         $"'{str}' cannot be below {_minValue}", ErrorRelevanceConfidence.Likely));
                 }
                 if (number > _maxValue)
                 {
-                    return Task.FromResult(ArgsParseResult<int>.Failure(
+                    return Task.FromResult(ArgsParseResult<T>.Failure(
                         $"'{str}' cannot be above {_maxValue}", ErrorRelevanceConfidence.Likely));
                 }
-                ArgsParseResult<int> result = ArgsParseResult<int>.Success(number, args.Skip(1).ToImmutableList());
+                ArgsParseResult<T> result =
+                    ArgsParseResult<T>.Success(new T { Number = number }, args.Skip(1).ToImmutableList());
                 return Task.FromResult(result);
             }
             catch (FormatException)
             {
-                return Task.FromResult(ArgsParseResult<int>.Failure($"did not recognize '{str}' as a number"));
+                return Task.FromResult(ArgsParseResult<T>.Failure($"did not recognize '{str}' as a number"));
             }
             catch (OverflowException)
             {
-                return Task.FromResult(ArgsParseResult<int>.Failure(
+                return Task.FromResult(ArgsParseResult<T>.Failure(
                     $"'{str}' is out of range", ErrorRelevanceConfidence.Likely));
             }
+        }
+    }
+
+    public class SignedIntParser : IntParser<SignedInt>
+    {
+        public SignedIntParser() : base(int.MinValue, int.MaxValue)
+        {
+        }
+    }
+
+    public class NonnegativeIntParser : IntParser<NonnegativeInt>
+    {
+        public NonnegativeIntParser() : base(0, int.MaxValue)
+        {
+        }
+    }
+
+    public class PositiveIntParser : IntParser<PositiveInt>
+    {
+        public PositiveIntParser() : base(1, int.MaxValue)
+        {
         }
     }
 }

--- a/TPP.ArgsParsing/Types/PrefixedNumbers.cs
+++ b/TPP.ArgsParsing/Types/PrefixedNumbers.cs
@@ -18,4 +18,13 @@ namespace TPP.ArgsParsing.Types
     public class SignedTokens : ImplicitNumber // may be negative
     {
     }
+    public class SignedInt : ImplicitNumber // may be negative
+    {
+    }
+    public class NonnegativeInt : ImplicitNumber // is always >= 0
+    {
+    }
+    public class PositiveInt : ImplicitNumber // is always >= 1
+    {
+    }
 }

--- a/TPP.ArgsParsing/Types/PrefixedNumbers.cs
+++ b/TPP.ArgsParsing/Types/PrefixedNumbers.cs
@@ -21,7 +21,7 @@ namespace TPP.ArgsParsing.Types
     public class SignedInt : ImplicitNumber // may be negative
     {
     }
-    public class NonnegativeInt : ImplicitNumber // is always >= 0
+    public class NonNegativeInt : ImplicitNumber // is always >= 0
     {
     }
     public class PositiveInt : ImplicitNumber // is always >= 1

--- a/TPP.Core.Tests/Commands/Definitions/UserCommandsTest.cs
+++ b/TPP.Core.Tests/Commands/Definitions/UserCommandsTest.cs
@@ -60,7 +60,7 @@ namespace TPP.Core.Tests.Commands.Definitions
             _argsParser.AddArgumentParser(new UserParser(_userRepoMock.Object));
             _argsParser.AddArgumentParser(new HexColorParser());
             _argsParser.AddArgumentParser(new StringParser());
-            _argsParser.AddArgumentParser(new IntParser());
+            _argsParser.AddArgumentParser(new NonnegativeIntParser());
         }
 
         [Test]

--- a/TPP.Core.Tests/Commands/Definitions/UserCommandsTest.cs
+++ b/TPP.Core.Tests/Commands/Definitions/UserCommandsTest.cs
@@ -60,7 +60,7 @@ namespace TPP.Core.Tests.Commands.Definitions
             _argsParser.AddArgumentParser(new UserParser(_userRepoMock.Object));
             _argsParser.AddArgumentParser(new HexColorParser());
             _argsParser.AddArgumentParser(new StringParser());
-            _argsParser.AddArgumentParser(new NonnegativeIntParser());
+            _argsParser.AddArgumentParser(new NonNegativeIntParser());
         }
 
         [Test]

--- a/TPP.Core/Commands/Definitions/UserCommands.cs
+++ b/TPP.Core/Commands/Definitions/UserCommands.cs
@@ -184,7 +184,7 @@ namespace TPP.Core.Commands.Definitions
         public async Task<CommandResult> SelectEmblem(CommandContext context)
         {
             User user = context.Message.User;
-            int emblem = await context.ParseArgs<NonnegativeInt>();
+            int emblem = await context.ParseArgs<NonNegativeInt>();
             if (!user.ParticipationEmblems.Contains(emblem))
             {
                 return new CommandResult { Response = "you don't own that participation badge" };

--- a/TPP.Core/Commands/Definitions/UserCommands.cs
+++ b/TPP.Core/Commands/Definitions/UserCommands.cs
@@ -184,7 +184,7 @@ namespace TPP.Core.Commands.Definitions
         public async Task<CommandResult> SelectEmblem(CommandContext context)
         {
             User user = context.Message.User;
-            int emblem = await context.ParseArgs<int>();
+            int emblem = await context.ParseArgs<NonnegativeInt>();
             if (!user.ParticipationEmblems.Contains(emblem))
             {
                 return new CommandResult { Response = "you don't own that participation badge" };

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -25,7 +25,9 @@ namespace TPP.Core
         public static ArgsParser SetUpArgsParser(IUserRepo userRepo, PokedexData pokedexData)
         {
             var argsParser = new ArgsParser();
-            argsParser.AddArgumentParser(new IntParser());
+            argsParser.AddArgumentParser(new SignedIntParser());
+            argsParser.AddArgumentParser(new PositiveIntParser());
+            argsParser.AddArgumentParser(new NonnegativeIntParser());
             argsParser.AddArgumentParser(new StringParser());
             argsParser.AddArgumentParser(new InstantParser());
             argsParser.AddArgumentParser(new TimeSpanParser());

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -27,7 +27,7 @@ namespace TPP.Core
             var argsParser = new ArgsParser();
             argsParser.AddArgumentParser(new SignedIntParser());
             argsParser.AddArgumentParser(new PositiveIntParser());
-            argsParser.AddArgumentParser(new NonnegativeIntParser());
+            argsParser.AddArgumentParser(new NonNegativeIntParser());
             argsParser.AddArgumentParser(new StringParser());
             argsParser.AddArgumentParser(new InstantParser());
             argsParser.AddArgumentParser(new TimeSpanParser());


### PR DESCRIPTION
In preparation for some future chat commands that need to
differentiate between signed, unsigned, and positive numbers.
This should prevent some bugs where a command author wasn't
explicit about a parameter's bounds and forgot to check it.