### PR TITLE
remove .NET 5 RCs from github workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,7 @@ jobs:
     strategy:
       matrix:
         dotnet-sdk-version:
-          - 5.0.100-rc.1.20452.10
-          - 5.0.100-rc.2.20479.15
-          - 5.0.100
+          - 5.0.102 # currently running on stream
           - 5.0.x
 
     steps:


### PR DESCRIPTION
We only need to test against the exact version we are currently running
and the latest version to notice breaking changes as soon as possible.