### PR TITLE
set output encoding to utf-8

### DIFF
--- a/TPP.Core/Program.cs
+++ b/TPP.Core/Program.cs
@@ -46,6 +46,7 @@ Options:
 
         private static void Main(string[] argv)
         {
+            Console.OutputEncoding = Encoding.UTF8;
             IDictionary<string, ValueObject> args = new Docopt().Apply(Usage, argv, exit: true);
             string? mode = null;
             string modeConfigFilename = args["--mode-config"].ToString();


### PR DESCRIPTION
This avoids the bullet character `•` being converted to \x07 (bell).
See also https://devblogs.microsoft.com/oldnewthing/20070104-00/?p=28513