### PR TITLE
add `giftbadge` and `transferbadge` commands

### DIFF
--- a/TPP.ArgsParsing/Types/Optional.cs
+++ b/TPP.ArgsParsing/Types/Optional.cs
@@ -40,6 +40,11 @@ namespace TPP.ArgsParsing.Types
             return IsPresent ? Value : fallback;
         }
 
+        public Optional<T2> Map<T2>(Func<T, T2> mapFunc) =>
+            IsPresent
+                ? new Optional<T2>(true, mapFunc(Value))
+                : new Optional<T2>(false, default!);
+
         public override string ToString()
             => IsPresent ? Value?.ToString() ?? "<null>" : "<none>";
     }

--- a/TPP.Core/Commands/Definitions/HelpCommand.cs
+++ b/TPP.Core/Commands/Definitions/HelpCommand.cs
@@ -211,7 +211,6 @@ namespace TPP.Core.Commands.Definitions
             ["cancelsellbadge"] = "Cancel trying to sell a species of badges. Argument: <Pokemon>",
             ["listbadgesnotforsale"] = "List all the badges you have that are not for sale.",
             ["listbadgesnotonsale"] = "List all the badges you have that are not for sale.",
-            ["giftbadge"] = "Gift a badge you own to another user with no price. Arguments: <pokemon> <number of badges>(Optional) <username>",
             ["transmute"] = "Transform 3 or more badges into a (usually) rarer badge. Costs one token. Arguments: <several Pokemon>(at least 3) t1",
 
             // misc

--- a/TPP.Core/Commands/Definitions/OperatorCommands.cs
+++ b/TPP.Core/Commands/Definitions/OperatorCommands.cs
@@ -110,7 +110,9 @@ namespace TPP.Core.Commands.Definitions
             if (isSelf)
             {
                 return new CommandResult
-                    { Response = $"Your {currencyName} balance was adjusted by {delta:+#;-#}. Reason: {reason}" };
+                {
+                    Response = $"Your {currencyName} balance was adjusted by {delta:+#;-#}. Reason: {reason}"
+                };
             }
             else
             {

--- a/TPP.Core/Commands/Definitions/OperatorCommands.cs
+++ b/TPP.Core/Commands/Definitions/OperatorCommands.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using TPP.ArgsParsing.Types;
+using TPP.Common;
 using TPP.Core.Chat;
 using TPP.Persistence.Models;
 using TPP.Persistence.Repos;
@@ -21,19 +22,22 @@ namespace TPP.Core.Commands.Definitions
         private readonly IBank<User> _pokeyenBank;
         private readonly IBank<User> _tokensBank;
         private readonly IMessageSender _messageSender;
+        private readonly IBadgeRepo _badgeRepo;
 
         public OperatorCommands(
             StopToken stopToken,
             IEnumerable<string> operatorNames,
             IBank<User> pokeyenBank,
             IBank<User> tokensBank,
-            IMessageSender messageSender)
+            IMessageSender messageSender,
+            IBadgeRepo badgeRepo)
         {
             _stopToken = stopToken;
             _operatorNamesLower = operatorNames.Select(s => s.ToLowerInvariant()).ToImmutableHashSet();
             _pokeyenBank = pokeyenBank;
             _tokensBank = tokensBank;
             _messageSender = messageSender;
+            _badgeRepo = badgeRepo;
         }
 
         public IEnumerable<Command> Commands => new[]
@@ -54,6 +58,11 @@ namespace TPP.Core.Commands.Definitions
                 Aliases = new[] { "adjusttokens" },
                 Description = "Operators only: Add or remove tokens from an user. " +
                               "Arguments: t<amount>(can be negative) <user> <reason>"
+            },
+            new Command("transferbadge", TransferBadge)
+            {
+                Description = "Operators only: Transfer badges from one user to another user. " +
+                              "Arguments: <gifter> <recipient> <pokemon> <number of badges>(Optional) <reason>"
             },
         }.Select(cmd => cmd.WithCondition(
             canExecute: ctx => IsOperator(ctx.Message.User),
@@ -101,7 +110,7 @@ namespace TPP.Core.Commands.Definitions
             if (isSelf)
             {
                 return new CommandResult
-                { Response = $"Your {currencyName} balance was adjusted by {delta:+#;-#}. Reason: {reason}" };
+                    { Response = $"Your {currencyName} balance was adjusted by {delta:+#;-#}. Reason: {reason}" };
             }
             else
             {
@@ -112,8 +121,51 @@ namespace TPP.Core.Commands.Definitions
                 await _messageSender.SendWhisper(user,
                     $"{context.Message.User.Name} adjusted your {currencyName} balance by {delta:+#;-#}. Reason: {reason}");
                 return new CommandResult
-                { Response = $"{user.Name}'s {currencyName} balance was adjusted by {delta:+#;-#}. Reason: {reason}" };
+                {
+                    Response = $"{user.Name}'s {currencyName} balance was adjusted by {delta:+#;-#}. Reason: {reason}"
+                };
             }
+        }
+
+        public async Task<CommandResult> TransferBadge(CommandContext context)
+        {
+            (User gifter, (User recipient, PkmnSpecies species, Optional<PositiveInt> amountOpt), string reason) =
+                await context.ParseArgs<User, AnyOrder<User, PkmnSpecies, Optional<PositiveInt>>, string>();
+            int amount = amountOpt.Map(i => i.Number).OrElse(1);
+
+            if (gifter == context.Message.User)
+                return new CommandResult { Response = "Use the regular gift command if you're the gifter" };
+
+            if (recipient == gifter)
+                return new CommandResult { Response = "Gifter cannot be equal to recipient" };
+
+            List<Badge> badges = await _badgeRepo.FindByUserAndSpecies(gifter.Id, species);
+            if (badges.Count < amount)
+                return new CommandResult
+                {
+                    Response =
+                        $"You tried to transfer {amount} {species} badges, but the gifter only has {badges.Count}."
+                };
+
+            IImmutableList<Badge> badgesToGift = badges.Take(amount).ToImmutableList();
+            var data = new Dictionary<string, object?>
+            {
+                ["gifter"] = gifter.Id,
+                ["responsible_user"] = context.Message.User.Id,
+                ["reason"] = reason
+            };
+            await _badgeRepo.TransferBadges(badgesToGift, recipient.Id, BadgeLogType.TransferGiftRemote, data);
+
+            await _messageSender.SendWhisper(recipient, amount > 1
+                ? $"{context.Message.User.Name} transferred {amount} {species} badges from {gifter.Name} to you. Reason: {reason}"
+                : $"{context.Message.User.Name} transferred a {species} badge from {gifter.Name} to you. Reason: {reason}");
+            return new CommandResult
+            {
+                Response = amount > 1
+                    ? $"transferred {amount} {species} badges from {gifter.Name} to {recipient.Name}. Reason: {reason}"
+                    : $"transferred a {species} badge from {gifter.Name} to {recipient.Name}. Reason: {reason}",
+                ResponseTarget = ResponseTarget.Chat
+            };
         }
     }
 }

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -65,10 +65,10 @@ namespace TPP.Core
                 new StaticResponseCommands().Commands,
                 new UserCommands(
                     databases.UserRepo, pokeyenBank: databases.PokeyenBank, tokenBank: databases.TokensBank).Commands,
-                new BadgeCommands(databases.BadgeRepo, databases.UserRepo, chat).Commands,
+                new BadgeCommands(databases.BadgeRepo, databases.UserRepo, messageSender).Commands,
                 new OperatorCommands(
                     stopToken, chatConfig.OperatorNames, databases.PokeyenBank, databases.TokensBank,
-                    messageSender: messageSender
+                    messageSender: messageSender, databases.BadgeRepo
                 ).Commands,
                 new ModeratorCommands(chatConfig.ModeratorNames, chatConfig.OperatorNames, chatModeChanger).Commands,
                 new MiscCommands().Commands,

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -65,7 +65,7 @@ namespace TPP.Core
                 new StaticResponseCommands().Commands,
                 new UserCommands(
                     databases.UserRepo, pokeyenBank: databases.PokeyenBank, tokenBank: databases.TokensBank).Commands,
-                new BadgeCommands(databases.BadgeRepo, databases.UserRepo).Commands,
+                new BadgeCommands(databases.BadgeRepo, databases.UserRepo, chat).Commands,
                 new OperatorCommands(
                     stopToken, chatConfig.OperatorNames, databases.PokeyenBank, databases.TokensBank,
                     messageSender: messageSender
@@ -95,6 +95,7 @@ namespace TPP.Core
 
         public static Databases SetUpRepositories(BaseConfig baseConfig)
         {
+            IClock clock = SystemClock.Instance;
             CustomSerializers.RegisterAll();
             IMongoClient mongoClient = new MongoClient(baseConfig.MongoDbConnectionUri);
             IMongoDatabase mongoDatabase = mongoClient.GetDatabase(baseConfig.MongoDbDatabaseName);
@@ -103,22 +104,24 @@ namespace TPP.Core
                 database: mongoDatabase,
                 startingPokeyen: baseConfig.StartingPokeyen,
                 startingTokens: baseConfig.StartingTokens);
-            IBadgeRepo badgeRepo = new BadgeRepo(
-                database: mongoDatabase);
+            IMongoBadgeLogRepo badgeLogRepo = new BadgeLogRepo(mongoDatabase);
+            IBadgeRepo badgeRepo = new BadgeRepo(mongoDatabase, badgeLogRepo, clock);
+            badgeRepo.UserLostBadgeSpecies += async (_, args) =>
+                await userRepo.UnselectBadgeIfSpeciesSelected(args.UserId, args.Species);
             IBank<User> pokeyenBank = new Bank<User>(
                 database: mongoDatabase,
                 currencyCollectionName: UserRepo.CollectionName,
                 transactionLogCollectionName: "pokeyentransactions",
                 u => u.Pokeyen,
                 u => u.Id,
-                clock: SystemClock.Instance);
+                clock: clock);
             IBank<User> tokenBank = new Bank<User>(
                 database: mongoDatabase,
                 currencyCollectionName: UserRepo.CollectionName,
                 transactionLogCollectionName: "tokentransactions",
                 u => u.Tokens,
                 u => u.Id,
-                clock: SystemClock.Instance);
+                clock: clock);
             tokenBank.AddReservedMoneyChecker(
                 new PersistedReservedMoneyCheckers(mongoDatabase).AllDatabaseReservedTokens);
             return new Databases
@@ -127,7 +130,7 @@ namespace TPP.Core
                 BadgeRepo: badgeRepo,
                 PokeyenBank: pokeyenBank,
                 TokensBank: tokenBank,
-                CommandLogger: new CommandLogger(mongoDatabase, SystemClock.Instance),
+                CommandLogger: new CommandLogger(mongoDatabase, clock),
                 MessagequeueRepo: new MessagequeueRepo(mongoDatabase),
                 MessagelogRepo: new MessagelogRepo(mongoDatabaseMessagelog)
             );

--- a/TPP.Persistence.MongoDB.Tests/Repos/BadgeLogRepoTest.cs
+++ b/TPP.Persistence.MongoDB.Tests/Repos/BadgeLogRepoTest.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using NodaTime;
+using NUnit.Framework;
+using TPP.Persistence.Models;
+using TPP.Persistence.MongoDB.Repos;
+
+namespace TPP.Persistence.MongoDB.Tests.Repos
+{
+    public class BadgeLogRepoTest : MongoTestBase
+    {
+        [Test]
+        public async Task persists_successfully()
+        {
+            BadgeLogRepo repo = new(CreateTemporaryDatabase());
+            string badgeId = ObjectId.GenerateNewId().ToString();
+            const string badgeLogType = "type";
+            const string userId = "user";
+            Instant timestamp = Instant.FromUnixTimeSeconds(123);
+
+            // persist to db
+            IDictionary<string, object?> data = new Dictionary<string, object?> { ["some"] = "data" };
+            BadgeLog written = await repo.Log(badgeId, badgeLogType, userId, timestamp, data);
+            Assert.AreEqual(badgeId, written.BadgeId);
+            Assert.AreEqual(badgeLogType, written.BadgeLogType);
+            Assert.AreEqual(userId, written.UserId);
+            Assert.AreEqual(timestamp, written.Timestamp);
+            Assert.AreEqual(data, written.AdditionalData);
+            Assert.NotNull(written.Id);
+
+            // read from db
+            List<BadgeLog> allItems = await repo.Collection.Find(FilterDefinition<BadgeLog>.Empty).ToListAsync();
+            Assert.AreEqual(1, allItems.Count);
+            BadgeLog read = allItems[0];
+            Assert.AreEqual(written, read);
+            Assert.AreEqual(badgeId, read.BadgeId);
+            Assert.AreEqual(badgeLogType, read.BadgeLogType);
+            Assert.AreEqual(userId, read.UserId);
+            Assert.AreEqual(timestamp, read.Timestamp);
+            Assert.AreEqual(data, read.AdditionalData);
+        }
+    }
+}

--- a/TPP.Persistence.MongoDB.Tests/Repos/BadgeRepoTest.cs
+++ b/TPP.Persistence.MongoDB.Tests/Repos/BadgeRepoTest.cs
@@ -3,10 +3,13 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using Moq;
+using NodaTime;
 using NUnit.Framework;
 using TPP.Common;
 using TPP.Persistence.Models;
 using TPP.Persistence.MongoDB.Repos;
+using TPP.Persistence.Repos;
 
 namespace TPP.Persistence.MongoDB.Tests.Repos
 {
@@ -14,10 +17,13 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
     [Parallelizable(ParallelScope.All)]
     public class BadgeRepoTest : MongoTestBase
     {
+        public BadgeRepo CreateBadgeRepo() =>
+            new BadgeRepo(CreateTemporaryDatabase(), Mock.Of<IMongoBadgeLogRepo>(), Mock.Of<IClock>());
+
         [Test]
         public async Task insert_then_read_are_equal()
         {
-            var badgeRepo = new BadgeRepo(CreateTemporaryDatabase());
+            BadgeRepo badgeRepo = CreateBadgeRepo();
             // when
             Badge badge = await badgeRepo.AddBadge(null, PkmnSpecies.OfId("16"), Badge.BadgeSource.ManualCreation);
 
@@ -36,7 +42,7 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
         [Test]
         public async Task has_expected_bson_datatypes()
         {
-            var badgeRepo = new BadgeRepo(CreateTemporaryDatabase());
+            BadgeRepo badgeRepo = CreateBadgeRepo();
             // when
             PkmnSpecies randomSpecies = PkmnSpecies.OfId("9001");
             Badge badge = await badgeRepo.AddBadge(null, randomSpecies, Badge.BadgeSource.RunCaught);
@@ -54,7 +60,7 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
         [Test]
         public async Task can_find_by_user()
         {
-            var badgeRepo = new BadgeRepo(CreateTemporaryDatabase());
+            IBadgeRepo badgeRepo = CreateBadgeRepo();
             // given
             Badge badgeUserA1 = await badgeRepo.AddBadge("userA", PkmnSpecies.OfId("1"), Badge.BadgeSource.Pinball);
             Badge badgeUserA2 = await badgeRepo.AddBadge("userA", PkmnSpecies.OfId("2"), Badge.BadgeSource.Pinball);
@@ -75,7 +81,7 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
         [Test]
         public async Task can_count_by_user_and_species()
         {
-            var badgeRepo = new BadgeRepo(CreateTemporaryDatabase());
+            IBadgeRepo badgeRepo = CreateBadgeRepo();
             // given
             await badgeRepo.AddBadge("user", PkmnSpecies.OfId("2"), Badge.BadgeSource.Pinball);
             await badgeRepo.AddBadge("user", PkmnSpecies.OfId("3"), Badge.BadgeSource.Pinball);
@@ -99,7 +105,7 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
         [Test]
         public async Task can_count_per_species_for_one_user()
         {
-            var badgeRepo = new BadgeRepo(CreateTemporaryDatabase());
+            IBadgeRepo badgeRepo = CreateBadgeRepo();
             // given
             await badgeRepo.AddBadge("user", PkmnSpecies.OfId("2"), Badge.BadgeSource.Pinball);
             await badgeRepo.AddBadge("user", PkmnSpecies.OfId("3"), Badge.BadgeSource.Pinball);
@@ -124,7 +130,7 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
         [Test]
         public async Task can_check_if_user_has_badge()
         {
-            var badgeRepo = new BadgeRepo(CreateTemporaryDatabase());
+            IBadgeRepo badgeRepo = CreateBadgeRepo();
             // given
             await badgeRepo.AddBadge("user", PkmnSpecies.OfId("2"), Badge.BadgeSource.Pinball);
             await badgeRepo.AddBadge("user", PkmnSpecies.OfId("3"), Badge.BadgeSource.Pinball);
@@ -144,6 +150,120 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
             Assert.IsTrue(hasUserSpecies2);
             Assert.IsTrue(hasUserSpecies3);
             Assert.IsFalse(hasUserSpecies4);
+        }
+
+        [TestFixture]
+        private class TransferBadge : MongoTestBase
+        {
+            [Test]
+            public async Task returns_updated_badge_object()
+            {
+                IBadgeRepo badgeRepo = new BadgeRepo(
+                    CreateTemporaryDatabase(), Mock.Of<IMongoBadgeLogRepo>(), Mock.Of<IClock>());
+                Badge badge = await badgeRepo.AddBadge(
+                    "user", PkmnSpecies.OfId("1"), Badge.BadgeSource.ManualCreation);
+
+                IImmutableList<Badge> updatedBadges = await badgeRepo.TransferBadges(
+                    ImmutableList.Create(badge), "recipient", "reason", new Dictionary<string, object?>());
+
+                Assert.AreEqual(1, updatedBadges.Count);
+                Assert.AreEqual(badge.Id, updatedBadges[0].Id);
+                Assert.AreEqual(badge.Species, updatedBadges[0].Species);
+                Assert.AreEqual(badge.Source, updatedBadges[0].Source);
+                Assert.AreEqual(badge.CreatedAt, updatedBadges[0].CreatedAt);
+                Assert.AreEqual("recipient", updatedBadges[0].UserId);
+            }
+
+            [Test]
+            public async Task unmarks_as_selling()
+            {
+                BadgeRepo badgeRepo = new(CreateTemporaryDatabase(), Mock.Of<IMongoBadgeLogRepo>(), Mock.Of<IClock>());
+                Badge badge = await badgeRepo.AddBadge(
+                    "user", PkmnSpecies.OfId("1"), Badge.BadgeSource.ManualCreation);
+                await badgeRepo.Collection.UpdateOneAsync(
+                    Builders<Badge>.Filter.Where(b => b.Id == badge.Id),
+                    Builders<Badge>.Update
+                        .Set(b => b.SellingSince, Instant.FromUnixTimeSeconds(0))
+                        .Set(b => b.SellPrice, 123));
+
+                IImmutableList<Badge> updatedBadges = await badgeRepo.TransferBadges(
+                    ImmutableList.Create(badge), "recipient", "reason", new Dictionary<string, object?>());
+
+                Assert.AreEqual(1, updatedBadges.Count);
+                Assert.IsNull(updatedBadges[0].SellingSince);
+                Assert.IsNull(updatedBadges[0].SellPrice);
+                Badge updatedBadge = await badgeRepo.Collection.Find(b => b.Id == badge.Id).FirstAsync();
+                Assert.AreEqual(updatedBadge, updatedBadges[0]);
+                Assert.IsNull(updatedBadge.SellingSince);
+                Assert.IsNull(updatedBadge.SellPrice);
+            }
+
+            [Test]
+            public async Task logs_to_badgelog()
+            {
+                Mock<IClock> clockMock = new();
+                Mock<IMongoBadgeLogRepo> mongoBadgeLogRepoMock = new();
+                BadgeRepo badgeRepo = new(CreateTemporaryDatabase(), mongoBadgeLogRepoMock.Object, clockMock.Object);
+                Badge badge = await badgeRepo.AddBadge(
+                    "user", PkmnSpecies.OfId("1"), Badge.BadgeSource.ManualCreation);
+
+                Instant timestamp = Instant.FromUnixTimeSeconds(123);
+                clockMock.Setup(c => c.GetCurrentInstant()).Returns(timestamp);
+
+                IDictionary<string, object?> data = new Dictionary<string, object?> { ["some"] = "data" };
+                await badgeRepo.TransferBadges(ImmutableList.Create(badge), "recipient", "reason", data);
+
+                mongoBadgeLogRepoMock.Verify(l => l.LogWithSession(
+                        badge.Id, "reason", "recipient", timestamp, data, It.IsAny<IClientSessionHandle>()),
+                    Times.Once);
+            }
+
+            [Test]
+            public async Task triggers_species_lost_event()
+            {
+                Mock<IMongoBadgeLogRepo> mongoBadgeLogRepoMock = new();
+                BadgeRepo badgeRepo = new(CreateTemporaryDatabase(), mongoBadgeLogRepoMock.Object, Mock.Of<IClock>());
+                PkmnSpecies species = PkmnSpecies.OfId("1");
+                Badge badge1 = await badgeRepo.AddBadge("user", species, Badge.BadgeSource.ManualCreation);
+                Badge badge2 = await badgeRepo.AddBadge("user", species, Badge.BadgeSource.ManualCreation);
+                int userLostBadgeInvocations = 0;
+                badgeRepo.UserLostBadgeSpecies += (_, args) =>
+                {
+                    Assert.AreEqual("user", args.UserId);
+                    Assert.AreEqual(species, args.Species);
+                    userLostBadgeInvocations++;
+                };
+
+                await badgeRepo.TransferBadges(
+                    ImmutableList.Create(badge1), "recipient", "reason", new Dictionary<string, object?>());
+                Assert.AreEqual(0, userLostBadgeInvocations, "one badge of species left");
+                await badgeRepo.TransferBadges(
+                    ImmutableList.Create(badge2), "recipient", "reason", new Dictionary<string, object?>());
+                Assert.AreEqual(1, userLostBadgeInvocations, "last badge of species lost");
+            }
+
+            [Test]
+            public async Task aborts_all_transfers_if_one_fails()
+            {
+                Mock<IMongoBadgeLogRepo> mongoBadgeLogRepoMock = new();
+                BadgeRepo badgeRepo = new(CreateTemporaryDatabase(), mongoBadgeLogRepoMock.Object, Mock.Of<IClock>());
+                PkmnSpecies species = PkmnSpecies.OfId("1");
+                Badge badge1 = await badgeRepo.AddBadge("user", species, Badge.BadgeSource.ManualCreation);
+                Badge badge2 = await badgeRepo.AddBadge("user", species, Badge.BadgeSource.ManualCreation);
+                // make in-memory badge reference stale to cause the transfer to fail on the second badge
+                await badgeRepo.Collection.UpdateOneAsync(
+                    Builders<Badge>.Filter.Where(b => b.Id == badge2.Id),
+                    Builders<Badge>.Update.Set(b => b.UserId, "someOtherUser"));
+
+                OwnedBadgeNotFoundException ex = Assert.ThrowsAsync<OwnedBadgeNotFoundException>(() =>
+                    badgeRepo.TransferBadges(ImmutableList.Create(badge1, badge2),
+                        "recipient", "reason", new Dictionary<string, object?>()));
+                Assert.AreEqual(badge2, ex.Badge);
+                // first badge must not have changed ownership
+                Badge firstBadge = await badgeRepo.Collection.Find(b => b.Id == badge1.Id).FirstAsync();
+                Assert.AreEqual("user", firstBadge.UserId);
+                Assert.AreEqual(badge1, firstBadge);
+            }
         }
     }
 }

--- a/TPP.Persistence.MongoDB/Repos/BadgeLogRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/BadgeLogRepo.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Driver;
+using NodaTime;
+using TPP.Persistence.Models;
+using TPP.Persistence.MongoDB.Serializers;
+using TPP.Persistence.Repos;
+
+namespace TPP.Persistence.MongoDB.Repos
+{
+    /// <summary>
+    /// MongoDB-specific extension of <see cref="IBadgeLogRepo"/> which is required because <see cref="BadgeRepo"/>
+    /// needs to additionally pass <see cref="IClientSessionHandle"/>s to be able to log within a transaction.
+    /// </summary>
+    public interface IMongoBadgeLogRepo : IBadgeLogRepo
+    {
+        Task<BadgeLog> LogWithSession(
+            string badgeId, string badgeLogType, string? userId, Instant timestamp,
+            IDictionary<string, object?>? additionalData = null,
+            IClientSessionHandle? session = null);
+    }
+
+    public class BadgeLogRepo : IMongoBadgeLogRepo
+    {
+        public const string CollectionName = "badgelog";
+
+        public readonly IMongoCollection<BadgeLog> Collection;
+
+        static BadgeLogRepo()
+        {
+            BsonClassMap.RegisterClassMap<BadgeLog>(cm =>
+            {
+                cm.MapIdProperty(b => b.Id)
+                    .SetIdGenerator(StringObjectIdGenerator.Instance)
+                    .SetSerializer(ObjectIdAsStringSerializer.Instance);
+                cm.MapProperty(b => b.BadgeId).SetElementName("badge")
+                    .SetSerializer(ObjectIdAsStringSerializer.Instance);
+                cm.MapProperty(b => b.BadgeLogType).SetElementName("event");
+                cm.MapProperty(b => b.UserId).SetElementName("user");
+                cm.MapProperty(b => b.Timestamp).SetElementName("ts");
+                cm.MapExtraElementsProperty(b => b.AdditionalData);
+            });
+        }
+
+        public BadgeLogRepo(IMongoDatabase database)
+        {
+            database.CreateCollectionIfNotExists(CollectionName).Wait();
+            Collection = database.GetCollection<BadgeLog>(CollectionName);
+        }
+
+        public async Task<BadgeLog> LogWithSession(
+            string badgeId, string badgeLogType, string? userId, Instant timestamp,
+            IDictionary<string, object?>? additionalData = null,
+            IClientSessionHandle? session = null)
+        {
+            var item = new BadgeLog(string.Empty, badgeId, badgeLogType, userId, timestamp,
+                additionalData ?? ImmutableDictionary<string, object?>.Empty);
+            if (session != null)
+                await Collection.InsertOneAsync(session, item);
+            else
+                await Collection.InsertOneAsync(item);
+            Debug.Assert(item.Id.Length > 0, "The MongoDB driver injected a generated ID");
+            return item;
+        }
+
+        public Task<BadgeLog> Log(string badgeId, string badgeLogType, string? userId, Instant timestamp,
+            IDictionary<string, object?>? additionalData = null) =>
+            LogWithSession(badgeId, badgeLogType, userId, timestamp, additionalData, session: null);
+    }
+}

--- a/TPP.Persistence.MongoDB/Repos/BadgeRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/BadgeRepo.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.IdGenerators;
@@ -20,6 +22,8 @@ namespace TPP.Persistence.MongoDB.Repos
         private const string CollectionName = "badges";
 
         public readonly IMongoCollection<Badge> Collection;
+        private readonly IMongoBadgeLogRepo _badgeLogRepo;
+        private readonly IClock _clock;
 
         static BadgeRepo()
         {
@@ -32,13 +36,17 @@ namespace TPP.Persistence.MongoDB.Repos
                 cm.MapProperty(b => b.Species).SetElementName("species");
                 cm.MapProperty(b => b.Source).SetElementName("source");
                 cm.MapProperty(b => b.CreatedAt).SetElementName("created_at");
+                cm.MapProperty(b => b.SellPrice).SetElementName("sell_price");
+                cm.MapProperty(b => b.SellingSince).SetElementName("selling_since");
             });
         }
 
-        public BadgeRepo(IMongoDatabase database)
+        public BadgeRepo(IMongoDatabase database, IMongoBadgeLogRepo badgeLogRepo, IClock clock)
         {
             database.CreateCollectionIfNotExists(CollectionName).Wait();
             Collection = database.GetCollection<Badge>(CollectionName);
+            _badgeLogRepo = badgeLogRepo;
+            _clock = clock;
             InitIndexes();
         }
 
@@ -70,6 +78,9 @@ namespace TPP.Persistence.MongoDB.Repos
         public async Task<List<Badge>> FindByUser(string? userId) =>
             await Collection.Find(b => b.UserId == userId).ToListAsync();
 
+        public async Task<List<Badge>> FindByUserAndSpecies(string? userId, PkmnSpecies species) =>
+            await Collection.Find(b => b.UserId == userId && b.Species == species).ToListAsync();
+
         public async Task<long> CountByUserAndSpecies(string? userId, PkmnSpecies species) =>
             await Collection.CountDocumentsAsync(b => b.UserId == userId && b.Species == species);
 
@@ -90,5 +101,58 @@ namespace TPP.Persistence.MongoDB.Repos
             await Collection
                 .Find(b => b.Species == species && b.UserId == userId)
                 .AnyAsync();
+
+        public event EventHandler<UserLostBadgeSpeciesEventArgs>? UserLostBadgeSpecies;
+
+        private async Task<Badge> TransferBadge(
+            Badge badge, string? recipientUserId, IClientSessionHandle session, CancellationToken cancellationToken)
+        {
+            if (badge.UserId == recipientUserId)
+                throw new ArgumentException($"badge {badge} is already owned by user with id {recipientUserId}");
+            return await Collection.FindOneAndUpdateAsync(session,
+                       Builders<Badge>.Filter
+                           .Where(b => b.Id == badge.Id && b.UserId == badge.UserId),
+                       Builders<Badge>.Update
+                           .Set(b => b.UserId, recipientUserId)
+                           .Unset(b => b.SellPrice)
+                           .Unset(b => b.SellingSince),
+                       new FindOneAndUpdateOptions<Badge> { ReturnDocument = ReturnDocument.After, IsUpsert = false },
+                       cancellationToken)
+                   ?? throw new OwnedBadgeNotFoundException(badge);
+        }
+
+        public async Task<IImmutableList<Badge>> TransferBadges(
+            IImmutableList<Badge> badges, string? recipientUserId, string reason,
+            IDictionary<string, object?> additionalData)
+        {
+            Instant now = _clock.GetCurrentInstant();
+
+            List<Badge> updatedBadges = new();
+            using (IClientSessionHandle sessionOuter = await Collection.Database.Client.StartSessionAsync())
+            {
+                await sessionOuter.WithTransactionAsync(async (txSession, txToken) =>
+                {
+                    foreach (Badge badge in badges)
+                    {
+                        Badge updatedBadge = await TransferBadge(badge, recipientUserId, txSession, txToken);
+                        Debug.Assert(badge.Id == updatedBadge.Id);
+                        updatedBadges.Add(updatedBadge);
+                    }
+
+                    foreach (Badge badge in badges)
+                        await _badgeLogRepo.LogWithSession(
+                            badge.Id, reason, recipientUserId, now, additionalData, txSession);
+                    return (object?)null;
+                });
+            }
+
+            foreach (var tpl in badges.Select(b => (b.UserId, b.Species)).Distinct())
+            {
+                (string? previousOwnerUserId, PkmnSpecies species) = tpl;
+                if (previousOwnerUserId != null && !await HasUserBadge(previousOwnerUserId, species))
+                    UserLostBadgeSpecies?.Invoke(this, new UserLostBadgeSpeciesEventArgs(previousOwnerUserId, species));
+            }
+            return updatedBadges.ToImmutableList();
+        }
     }
 }

--- a/TPP.Persistence.MongoDB/Repos/BadgeRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/BadgeRepo.cs
@@ -36,8 +36,10 @@ namespace TPP.Persistence.MongoDB.Repos
                 cm.MapProperty(b => b.Species).SetElementName("species");
                 cm.MapProperty(b => b.Source).SetElementName("source");
                 cm.MapProperty(b => b.CreatedAt).SetElementName("created_at");
-                cm.MapProperty(b => b.SellPrice).SetElementName("sell_price");
-                cm.MapProperty(b => b.SellingSince).SetElementName("selling_since");
+                cm.MapProperty(b => b.SellPrice).SetElementName("sell_price")
+                    .SetIgnoreIfNull(true);
+                cm.MapProperty(b => b.SellingSince).SetElementName("selling_since")
+                    .SetIgnoreIfNull(true);
             });
         }
 

--- a/TPP.Persistence.MongoDB/Repos/Bank.cs
+++ b/TPP.Persistence.MongoDB/Repos/Bank.cs
@@ -126,7 +126,8 @@ namespace TPP.Persistence.MongoDB.Repos
                 change: transaction.Change,
                 createdAt: _clock.GetCurrentInstant(),
                 type: transaction.Type,
-                additionalData: transaction.AdditionalData
+                // don't trust the input not to be modified, make a copy first:
+                additionalData: new Dictionary<string, object?>(transaction.AdditionalData)
             );
             await _transactionLogCollection.InsertOneAsync(session, transactionLog, cancellationToken: token);
             Debug.Assert(transactionLog.Id.Length > 0, "The MongoDB driver injected a generated ID");

--- a/TPP.Persistence.MongoDB/Repos/UserRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/UserRepo.cs
@@ -89,11 +89,13 @@ namespace TPP.Persistence.MongoDB.Repos
             {
                 update = update.Set(u => u.LastMessageAt, userInfo.UpdatedAt);
             }
+
             async Task<User?> UpdateExistingUser() => await Collection.FindOneAndUpdateAsync<User>(
                 filter: u => u.Id == userInfo.Id,
                 update: update,
                 options: new FindOneAndUpdateOptions<User> { ReturnDocument = ReturnDocument.After, IsUpsert = false }
             );
+
             User? user = await UpdateExistingUser();
             if (user != null)
             {
@@ -153,5 +155,12 @@ namespace TPP.Persistence.MongoDB.Repos
 
         public Task<User> SetDisplayName(User user, string displayName) =>
             UpdateField(user, u => u.Name, displayName);
+
+        public async Task<User> UnselectBadgeIfSpeciesSelected(string userId, PkmnSpecies species) =>
+            await Collection.FindOneAndUpdateAsync<User>(
+                filter: u => u.Id == userId && u.SelectedBadge == species,
+                update: Builders<User>.Update.Set(u => u.SelectedBadge, null),
+                options: new FindOneAndUpdateOptions<User> { ReturnDocument = ReturnDocument.After, IsUpsert = false })
+            ?? throw new ArgumentException($"user for ID {userId} does not exist");
     }
 }

--- a/TPP.Persistence/Models/Badge.cs
+++ b/TPP.Persistence/Models/Badge.cs
@@ -43,6 +43,11 @@ namespace TPP.Persistence.Models
         /// </summary>
         public Instant CreatedAt { get; init; }
 
+        /// If this badge is on sale, for how much.
+        public long? SellPrice { get; init; }
+        /// If this badge is on sale, since when.
+        public Instant? SellingSince { get; init; }
+
         public Badge(
             string id,
             string? userId,

--- a/TPP.Persistence/Models/BadgeLog.cs
+++ b/TPP.Persistence/Models/BadgeLog.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using NodaTime;
+using TPP.Common;
+
+namespace TPP.Persistence.Models
+{
+    public sealed record BadgeLog(
+        string Id,
+        string BadgeId,
+        string BadgeLogType,
+        string? UserId,
+        Instant Timestamp,
+        IDictionary<string, object?> AdditionalData)
+    {
+        public bool Equals(BadgeLog? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id
+                   && BadgeId == other.BadgeId
+                   && BadgeLogType == other.BadgeLogType
+                   && UserId == other.UserId
+                   && Timestamp.Equals(other.Timestamp)
+                   && AdditionalData.DictionaryEqual(other.AdditionalData); // <-- Equals() is overridden just for this
+        }
+
+        public override int GetHashCode() =>
+            HashCode.Combine(Id, BadgeId, BadgeLogType, UserId, Timestamp, AdditionalData);
+    }
+}

--- a/TPP.Persistence/Repos/IBadgeLogRepo.cs
+++ b/TPP.Persistence/Repos/IBadgeLogRepo.cs
@@ -8,6 +8,7 @@ namespace TPP.Persistence.Repos
     public static class BadgeLogType
     {
         public const string TransferGift = "gift";
+        public const string TransferGiftRemote = "gift_remote";
 
         // collect all the types being used here instead of scattering string literals across the codebase
     }

--- a/TPP.Persistence/Repos/IBadgeLogRepo.cs
+++ b/TPP.Persistence/Repos/IBadgeLogRepo.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NodaTime;
+using TPP.Persistence.Models;
+
+namespace TPP.Persistence.Repos
+{
+    public static class BadgeLogType
+    {
+        public const string TransferGift = "gift";
+
+        // collect all the types being used here instead of scattering string literals across the codebase
+    }
+
+    public interface IBadgeLogRepo
+    {
+        public Task<BadgeLog> Log(
+            string badgeId,
+            string badgeLogType,
+            string? userId,
+            Instant timestamp,
+            IDictionary<string, object?>? additionalData = null);
+    }
+}

--- a/TPP.Persistence/Repos/IBadgeRepo.cs
+++ b/TPP.Persistence/Repos/IBadgeRepo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -6,12 +7,46 @@ using TPP.Persistence.Models;
 
 namespace TPP.Persistence.Repos
 {
+    public class UserLostBadgeSpeciesEventArgs : EventArgs
+    {
+        public string UserId { get; }
+        public PkmnSpecies Species { get; }
+
+        public UserLostBadgeSpeciesEventArgs(string userId, PkmnSpecies species)
+        {
+            UserId = userId;
+            Species = species;
+        }
+    }
+
+    /// <summary>
+    /// Exception thrown when a badge related operation failed because the badge did not exist for a user.
+    /// </summary>
+    public class OwnedBadgeNotFoundException : Exception
+    {
+        public Badge Badge { get; }
+
+        public OwnedBadgeNotFoundException(Badge badge) :
+            base($"Badge '{badge}' was not found for user {badge.UserId}. " +
+                 "It's possible the badge object is stale due to a concurrent modification.")
+        {
+            Badge = badge;
+        }
+    }
+
     public interface IBadgeRepo
     {
         public Task<Badge> AddBadge(string? userId, PkmnSpecies species, Badge.BadgeSource source);
         public Task<List<Badge>> FindByUser(string? userId);
+        public Task<List<Badge>> FindByUserAndSpecies(string? userId, PkmnSpecies species);
         public Task<long> CountByUserAndSpecies(string? userId, PkmnSpecies species);
         public Task<ImmutableSortedDictionary<PkmnSpecies, int>> CountByUserPerSpecies(string? userId);
         public Task<bool> HasUserBadge(string? userId, PkmnSpecies species);
+
+        public event EventHandler<UserLostBadgeSpeciesEventArgs> UserLostBadgeSpecies;
+
+        public Task<IImmutableList<Badge>> TransferBadges(
+            IImmutableList<Badge> badges, string? recipientUserId, string reason,
+            IDictionary<string, object?> additionalData);
     }
 }

--- a/TPP.Persistence/Repos/IUserRepo.cs
+++ b/TPP.Persistence/Repos/IUserRepo.cs
@@ -14,5 +14,9 @@ namespace TPP.Persistence.Repos
         public Task<User> SetGlowColor(User user, string? glowColor);
         public Task<User> SetGlowColorUnlocked(User user, bool unlocked);
         public Task<User> SetDisplayName(User user, string displayName);
+
+        /// Unselects the specified species as the presented badge if it is the currently equipped species.
+        /// Used for resetting the equipped badge after a user lost all of that species' badges.
+        public Task<User> UnselectBadgeIfSpeciesSelected(string userId, PkmnSpecies species);
     }
 }


### PR DESCRIPTION
`giftbadge` is ported from old core, while `transferbadge` is new and allows operators to gift badges remotely.

This branch is based on https://github.com/TwitchPlaysPokemon/tpp-core/pull/190, so that should be merged first.