### PR TITLE
ArgsParsing: fix AnyOrder short-circuiting on first result

### DIFF
--- a/TPP.ArgsParsing.Tests/TypeParsersTest.cs
+++ b/TPP.ArgsParsing.Tests/TypeParsersTest.cs
@@ -56,6 +56,24 @@ namespace TPP.ArgsParsing.Tests
         }
 
         [Test]
+        public async Task TestAnyOrderLongestFirst()
+        {
+            var argsParser = new ArgsParser();
+            argsParser.AddArgumentParser(new AnyOrderParser(argsParser));
+            argsParser.AddArgumentParser(new OptionalParser(argsParser));
+            argsParser.AddArgumentParser(new SignedIntParser());
+            argsParser.AddArgumentParser(new StringParser());
+
+            // this used to fail because the optional made the first permutation fit with remaining arguments,
+            // instead of continuing to try all permutations and return the one consuming the most arguments.
+            (Optional<SignedInt> optionalInt, string str) = await argsParser
+                .Parse<AnyOrder<Optional<SignedInt>, string>>(ImmutableList.Create("abc", "123"));
+            Assert.True(optionalInt.IsPresent);
+            Assert.AreEqual(123, (int)optionalInt.Value);
+            Assert.AreEqual("abc", str);
+        }
+
+        [Test]
         public async Task TestAnyOrderSpareArgs()
         {
             var argsParser = new ArgsParser();

--- a/TPP.Core/Commands/Definitions/BadgeCommands.cs
+++ b/TPP.Core/Commands/Definitions/BadgeCommands.cs
@@ -76,7 +76,7 @@ namespace TPP.Core.Commands.Definitions
         public async Task<CommandResult> Badges(CommandContext context)
         {
             (Optional<PkmnSpecies> optionalSpecies, Optional<User> optionalUser) =
-                await context.ParseArgs<Optional<PkmnSpecies>, Optional<User>>();
+                await context.ParseArgs<AnyOrder<Optional<PkmnSpecies>, Optional<User>>>();
             bool isSelf = !optionalUser.IsPresent;
             User user = isSelf ? context.Message.User : optionalUser.Value;
             if (optionalSpecies.IsPresent)


### PR DESCRIPTION
This resulted in some scenarios, most notably in combination with Optional, where the AnyOrderParser would stop at the first valid permutation which happens to result in left-over arguments which could have been consumed by a different AnyOrder-permutation.
Fixes #112