### PR TITLE
allow concurrent positive bank transactions

### DIFF
--- a/TPP.Persistence.MongoDB/Repos/Bank.cs
+++ b/TPP.Persistence.MongoDB/Repos/Bank.cs
@@ -110,19 +110,24 @@ namespace TPP.Persistence.MongoDB.Repos
             T entityAfter = await _currencyCollection.FindOneAndUpdateAsync(session, filter, update, options, token)
                             ?? throw new UserNotFoundException<T>(transaction.User);
             long oldBalance = _currencyFieldAccessor(transaction.User);
-            long newBalance = _currencyFieldAccessor(entityAfter);
-            if (oldBalance + transaction.Change != newBalance)
+            long actualNewBalance = _currencyFieldAccessor(entityAfter);
+            long expectedNewBalance = oldBalance + transaction.Change;
+            if (actualNewBalance < expectedNewBalance)
             {
+                // This can happen for multiple concurrent modifications.
+                // Since we update the numeric field with an $inc operation, the resulting amount is correct.
+                // But to prevent overspending, abort if the actual new balance is _below_ the expected one.
+                // An unexpectedly high balance is okay, because that cannot lead to overspending.
                 throw new InvalidOperationException(
                     "Tried to perform transaction with stale user data: " +
                     $"old balance {oldBalance} plus change {transaction.Change} " +
-                    $"does not equal new balance {newBalance} for user {transaction.User}");
+                    $"does not equal new balance {actualNewBalance} for user {transaction.User}");
             }
             var transactionLog = new TransactionLog(
                 id: string.Empty,
                 userId: userId,
                 oldBalance: oldBalance,
-                newBalance: newBalance,
+                newBalance: actualNewBalance,
                 change: transaction.Change,
                 createdAt: _clock.GetCurrentInstant(),
                 type: transaction.Type,


### PR DESCRIPTION
It occurred to me today that the bank should gracefully handle concurrent transactions, e.g. if someone gifts 100 subs and gets 10 tokens per sub in quick succession. MongoDB already handles that fine, but I originally arbitrarily decided to abort transactions if they are operating on stale user data.
For cases where a user actually has more tokens than expected this just isn't a problem at all. For cases where a user has fewer tokens than expected it might also be preferable to go through with the transaction and risk them going into the negatives, but I opted for keeping the check for now as I am not entirely sure what is best in those cases.