### PR TITLE
UserRepo: add index on TwitchDisplayName

### DIFF
--- a/TPP.Persistence.MongoDB/Repos/UserRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/UserRepo.cs
@@ -70,6 +70,7 @@ namespace TPP.Persistence.MongoDB.Repos
             Collection.Indexes.CreateMany(new[]
             {
                 new CreateIndexModel<User>(Builders<User>.IndexKeys.Ascending(u => u.SimpleName)),
+                new CreateIndexModel<User>(Builders<User>.IndexKeys.Ascending(u => u.TwitchDisplayName)),
                 new CreateIndexModel<User>(Builders<User>.IndexKeys.Ascending(u => u.Pokeyen)),
                 new CreateIndexModel<User>(Builders<User>.IndexKeys.Ascending(u => u.Tokens)),
             });


### PR DESCRIPTION
a46fdc63 extended ArgsParsing's UserParser by finding users by their display name.
That field needs to be indexed now to not cause full collection scans for each lookup.