### PR TITLE
add subscription handling

### DIFF
--- a/TPP.Common/SubscriptionTier.cs
+++ b/TPP.Common/SubscriptionTier.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace TPP.Common
+{
+    public enum SubscriptionTier { Prime, Tier1, Tier2, Tier3 }
+
+    public static class SubscriberTierExtensions
+    {
+        /// The "rank" of a subscription tier is one increment per $5 worth of subscriptions. This allows the tiers
+        /// to be processed numerically instead of having to deal with every possible tier individually.
+        public static int ToRank(this SubscriptionTier tier) =>
+            tier switch
+            {
+                SubscriptionTier.Prime => 1,
+                SubscriptionTier.Tier1 => 1,
+                SubscriptionTier.Tier2 => 2,
+                SubscriptionTier.Tier3 => 5,
+                _ => throw new ArgumentOutOfRangeException(nameof(tier), tier, "unknown subscription tier")
+            };
+    }
+}

--- a/TPP.Core.Tests/SubscriptionTest.cs
+++ b/TPP.Core.Tests/SubscriptionTest.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NodaTime;
+using NUnit.Framework;
+using TPP.Common;
+using TPP.Persistence.Models;
+using TPP.Persistence.Repos;
+
+namespace TPP.Core.Tests
+{
+    public class SubscriptionProcessorTest
+    {
+        private static User MockUser(string name, int monthsSubscribed, SubscriptionTier? subscriptionTier,
+            int loyaltyLeague) => new User(
+            id: Guid.NewGuid().ToString(),
+            name: name, twitchDisplayName: "☺" + name, simpleName: name.ToLower(), color: null,
+            firstActiveAt: Instant.FromUnixTimeSeconds(0), lastActiveAt: Instant.FromUnixTimeSeconds(0),
+            lastMessageAt: null, pokeyen: 0, tokens: 0,
+            monthsSubscribed: monthsSubscribed, isSubscribed: subscriptionTier != null,
+            subscriptionTier: subscriptionTier, loyaltyLeague: loyaltyLeague);
+
+        [Test]
+        public async Task handle_regular_subscription()
+        {
+            // GIVEN
+            const SubscriptionTier subscriptionTier = SubscriptionTier.Tier2;
+            Instant subscribedAt = Instant.FromUnixTimeSeconds(123);
+            User user = MockUser("user", monthsSubscribed: 2, subscriptionTier, loyaltyLeague: 4);
+
+            Mock<IBank<User>> bankMock = new();
+            Mock<IUserRepo> userRepoMock = new();
+            Mock<ISubscriptionLogRepo> subscriptionLogRepoMock = new();
+            ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
+                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object);
+
+            userRepoMock.Setup(r => r.SetIsSubscribed(user, It.IsAny<bool>())).ReturnsAsync(user);
+            userRepoMock.Setup(r => r.SetSubscriptionInfo(user, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
+                It.IsAny<int>(), It.IsAny<Instant>())).ReturnsAsync(user);
+
+            // WHEN
+            ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
+                new SubscriptionInfo(
+                    user, NumMonths: 3, StreakMonths: 2, subscriptionTier, PlanName: "Tier 2",
+                    subscribedAt, Message: "HeyGuys", Gifter: null, IsAnonymous: false));
+
+            // THEN
+            const int expectedTokens = 10 + (2 * 4) + 10 + (2 * 5); // per rank: 10 base tokens + 2 tokens per league
+            // verify result
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubResult.Ok>(subResult);
+            var okResult = (ISubscriptionProcessor.SubResult.Ok)subResult;
+            Assert.AreEqual(3, okResult.CumulativeMonths);
+            Assert.AreEqual(expectedTokens, okResult.DeltaTokens);
+            Assert.AreEqual(4, okResult.OldLoyaltyLeague);
+            Assert.AreEqual(6, okResult.NewLoyaltyLeague);
+            Assert.IsFalse(okResult.SubCountCorrected);
+            Assert.IsNull(okResult.Gifter);
+
+            // verify tokens were awarded
+            IDictionary<string, object?> expectedData = new Dictionary<string, object?>
+            {
+                ["previous_months_subscribed"] = 2,
+                ["new_months_subscribed"] = 3,
+                ["months_difference"] = 1,
+                ["previous_loyalty_tier"] = 4,
+                ["new_loyalty_tier"] = 6,
+                ["loyalty_completions"] = 2,
+            };
+            bankMock.Verify(b =>
+                b.PerformTransaction(new Transaction<User>(user, expectedTokens, "subscription", expectedData),
+                    CancellationToken.None), Times.Once);
+
+            // verify user data was adjusted
+            userRepoMock.Verify(r => r.SetIsSubscribed(user, true), Times.Once);
+            userRepoMock.Verify(r => r.SetSubscriptionInfo(user, 3, subscriptionTier, 6, subscribedAt), Times.Once);
+
+            // verify subscription was logged
+            subscriptionLogRepoMock.Verify(r => r.LogSubscription(
+                    user.Id, subscribedAt,
+                    2, 2, 3, 1,
+                    4, 6, 2, expectedTokens,
+                    "HeyGuys", subscriptionTier, "Tier 2"),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task ignore_duplicate_month_same_rank()
+        {
+            // GIVEN
+            User user = MockUser("user", monthsSubscribed: 2, SubscriptionTier.Tier1, loyaltyLeague: 2);
+            Mock<IBank<User>> bankMock = new();
+            Mock<IUserRepo> userRepoMock = new();
+            Mock<ISubscriptionLogRepo> subscriptionLogRepoMock = new();
+            ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
+                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object);
+
+            // WHEN
+            ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
+                new SubscriptionInfo(
+                    user, NumMonths: 2, StreakMonths: 2, SubscriptionTier.Tier1, PlanName: "Sub Plan Name",
+                    Instant.MinValue, Message: "Repeated", Gifter: null, IsAnonymous: false));
+
+            // THEN
+            // negative result
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubResult.SameMonth>(subResult);
+            var sameMonthResult = (ISubscriptionProcessor.SubResult.SameMonth)subResult;
+            Assert.AreEqual(2, sameMonthResult.Month);
+            // no tokens were awarded
+            bankMock.VerifyNoOtherCalls();
+            // no user data was adjusted
+            userRepoMock.Verify(r => r.SetIsSubscribed(It.IsAny<User>(), It.IsAny<bool>()), Times.Never);
+            userRepoMock.Verify(r => r.SetSubscriptionInfo(It.IsAny<User>(), It.IsAny<int>(),
+                It.IsAny<SubscriptionTier>(), It.IsAny<int>(), It.IsAny<Instant>()), Times.Never);
+            // no subscription was logged
+            subscriptionLogRepoMock.VerifyNoOtherCalls();
+        }
+
+        [Test]
+        public async Task accept_duplicate_month_higher_rank()
+        {
+            // GIVEN
+            User user = MockUser("user", monthsSubscribed: 2, SubscriptionTier.Prime, loyaltyLeague: 2);
+            Instant subscribedAt = Instant.FromUnixTimeSeconds(123);
+            Mock<IBank<User>> bankMock = new();
+            Mock<IUserRepo> userRepoMock = new();
+            Mock<ISubscriptionLogRepo> subscriptionLogRepoMock = new();
+            ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
+                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object);
+
+            userRepoMock.Setup(r => r.SetIsSubscribed(user, It.IsAny<bool>())).ReturnsAsync(user);
+            userRepoMock.Setup(r => r.SetSubscriptionInfo(user, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
+                It.IsAny<int>(), It.IsAny<Instant>())).ReturnsAsync(user);
+
+            // WHEN
+            ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
+                new SubscriptionInfo(
+                    user, NumMonths: 2, StreakMonths: 2, SubscriptionTier.Tier3, PlanName: "Sub Plan Name",
+                    subscribedAt, Message: "Repeated", Gifter: null, IsAnonymous: false));
+
+            // THEN
+            const int expectedTokens = 14 + 16 + 18 + 20; // Tier 1 -> Tier 3: 4 loyalty completions difference
+            // negative result
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubResult.Ok>(subResult);
+            var okResult = (ISubscriptionProcessor.SubResult.Ok)subResult;
+            Assert.AreEqual(6, okResult.NewLoyaltyLeague);
+            Assert.AreEqual(2, okResult.CumulativeMonths);
+            // only tokens for rank upgrade were awarded
+            IDictionary<string, object?> expectedData = new Dictionary<string, object?>
+            {
+                ["previous_months_subscribed"] = 2,
+                ["new_months_subscribed"] = 2,
+                ["months_difference"] = 0,
+                ["previous_loyalty_tier"] = 2,
+                ["new_loyalty_tier"] = 6,
+                ["loyalty_completions"] = 4,
+            };
+            bankMock.Verify(b => b.PerformTransaction(
+                new Transaction<User>(user, expectedTokens, "subscription", expectedData),
+                CancellationToken.None), Times.Once);
+            // verify user data was adjusted
+            userRepoMock.Verify(r => r.SetIsSubscribed(user, true), Times.Once);
+            userRepoMock.Verify(r => r.SetSubscriptionInfo(user, 2, SubscriptionTier.Tier3, 6, subscribedAt),
+                Times.Once);
+            // verify subscription was logged
+            subscriptionLogRepoMock.Verify(r => r.LogSubscription(
+                    user.Id, subscribedAt,
+                    2, 2, 2, 0,
+                    2, 6, 4, expectedTokens,
+                    "Repeated", SubscriptionTier.Tier3, "Sub Plan Name"),
+                Times.Once);
+        }
+
+        [Test]
+        public async Task reward_sub_gift_tokens()
+        {
+            // GIVEN
+            User user = MockUser("user", monthsSubscribed: 2, SubscriptionTier.Prime, loyaltyLeague: 2);
+            Mock<IBank<User>> bankMock = new();
+            ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
+                bankMock.Object, Mock.Of<IUserRepo>(), Mock.Of<ISubscriptionLogRepo>());
+
+            ISubscriptionProcessor.SubGiftResult subGiftResult = await subscriptionProcessor.ProcessSubscriptionGift(
+                new SubscriptionGiftInfo(user, SubscriptionTier.Tier3, false));
+
+            const int expectedTokens = 10 * 5; // 10 per rank. Tier 3 has rank 5 because $25 = 5 * $5
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubGiftResult.Ok>(subGiftResult);
+            var okResult = (ISubscriptionProcessor.SubGiftResult.Ok)subGiftResult;
+            Assert.AreEqual(expectedTokens, okResult.DeltaTokens);
+            Assert.AreEqual(false, okResult.IsAnonymous);
+            IDictionary<string, object?> expectedData = new Dictionary<string, object?>();
+            bankMock.Verify(b => b.PerformTransaction(
+                new Transaction<User>(user, expectedTokens, "subscription gift", expectedData),
+                CancellationToken.None), Times.Once);
+        }
+    }
+}

--- a/TPP.Core.Tests/SubscriptionTest.cs
+++ b/TPP.Core.Tests/SubscriptionTest.cs
@@ -35,7 +35,7 @@ namespace TPP.Core.Tests
             Mock<IUserRepo> userRepoMock = new();
             Mock<ISubscriptionLogRepo> subscriptionLogRepoMock = new();
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
-                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object);
+                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object, Mock.Of<ILinkedAccountRepo>());
 
             userRepoMock.Setup(r => r.SetIsSubscribed(user, It.IsAny<bool>())).ReturnsAsync(user);
             userRepoMock.Setup(r => r.SetSubscriptionInfo(user, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
@@ -94,7 +94,7 @@ namespace TPP.Core.Tests
             Mock<IUserRepo> userRepoMock = new();
             Mock<ISubscriptionLogRepo> subscriptionLogRepoMock = new();
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
-                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object);
+                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object, Mock.Of<ILinkedAccountRepo>());
 
             // WHEN
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
@@ -127,7 +127,7 @@ namespace TPP.Core.Tests
             Mock<IUserRepo> userRepoMock = new();
             Mock<ISubscriptionLogRepo> subscriptionLogRepoMock = new();
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
-                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object);
+                bankMock.Object, userRepoMock.Object, subscriptionLogRepoMock.Object, Mock.Of<ILinkedAccountRepo>());
 
             userRepoMock.Setup(r => r.SetIsSubscribed(user, It.IsAny<bool>())).ReturnsAsync(user);
             userRepoMock.Setup(r => r.SetSubscriptionInfo(user, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
@@ -180,7 +180,7 @@ namespace TPP.Core.Tests
             Mock<IBank<User>> bankMock = new();
             Mock<IUserRepo> userRepoMock = new();
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
-                bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>());
+                bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>(), Mock.Of<ILinkedAccountRepo>());
             userRepoMock.Setup(r => r.SetIsSubscribed(recipient, It.IsAny<bool>())).ReturnsAsync(recipient);
             userRepoMock.Setup(r => r.SetSubscriptionInfo(recipient, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
                 It.IsAny<int>(), It.IsAny<Instant>())).ReturnsAsync(recipient);
@@ -231,7 +231,7 @@ namespace TPP.Core.Tests
             Mock<IBank<User>> bankMock = new();
             Mock<IUserRepo> userRepoMock = new();
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
-                bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>());
+                bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>(), Mock.Of<ILinkedAccountRepo>());
 
             SubscriptionInfo subscriptionInfo = new(recipient, NumMonths: 1, StreakMonths: 0, tier, "Sub Plan Name",
                 Instant.MinValue, "sub message", ImmutableList<EmoteOccurrence>.Empty);

--- a/TPP.Core.Tests/SubscriptionTest.cs
+++ b/TPP.Core.Tests/SubscriptionTest.cs
@@ -44,7 +44,7 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
                 new SubscriptionInfo(
                     user, NumMonths: 3, StreakMonths: 2, subscriptionTier, PlanName: "Tier 2",
-                    subscribedAt, Message: "HeyGuys", Gifter: null, IsAnonymous: false));
+                    subscribedAt, Message: "HeyGuys"));
 
             // THEN
             const int expectedTokens = 10 + (2 * 4) + 10 + (2 * 5); // per rank: 10 base tokens + 2 tokens per league
@@ -56,7 +56,6 @@ namespace TPP.Core.Tests
             Assert.AreEqual(4, okResult.OldLoyaltyLeague);
             Assert.AreEqual(6, okResult.NewLoyaltyLeague);
             Assert.IsFalse(okResult.SubCountCorrected);
-            Assert.IsNull(okResult.Gifter);
 
             // verify tokens were awarded
             IDictionary<string, object?> expectedData = new Dictionary<string, object?>
@@ -100,7 +99,7 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
                 new SubscriptionInfo(
                     user, NumMonths: 2, StreakMonths: 2, SubscriptionTier.Tier1, PlanName: "Sub Plan Name",
-                    Instant.MinValue, Message: "Repeated", Gifter: null, IsAnonymous: false));
+                    Instant.MinValue, Message: "Repeated"));
 
             // THEN
             // negative result
@@ -137,7 +136,7 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
                 new SubscriptionInfo(
                     user, NumMonths: 2, StreakMonths: 2, SubscriptionTier.Tier3, PlanName: "Sub Plan Name",
-                    subscribedAt, Message: "Repeated", Gifter: null, IsAnonymous: false));
+                    subscribedAt, Message: "Repeated"));
 
             // THEN
             const int expectedTokens = 14 + 16 + 18 + 20; // Tier 1 -> Tier 3: 4 loyalty completions difference
@@ -173,26 +172,81 @@ namespace TPP.Core.Tests
         }
 
         [Test]
-        public async Task reward_sub_gift_tokens()
+        public async Task handle_sub_gift_and_reward_gift_tokens()
         {
-            // GIVEN
-            User user = MockUser("user", monthsSubscribed: 2, SubscriptionTier.Prime, loyaltyLeague: 2);
+            User gifter = MockUser("gifter", monthsSubscribed: 2, SubscriptionTier.Prime, loyaltyLeague: 2);
+            User recipient = MockUser("recipient", monthsSubscribed: 0, subscriptionTier: null, loyaltyLeague: 0);
             Mock<IBank<User>> bankMock = new();
+            Mock<IUserRepo> userRepoMock = new();
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
-                bankMock.Object, Mock.Of<IUserRepo>(), Mock.Of<ISubscriptionLogRepo>());
+                bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>());
+            userRepoMock.Setup(r => r.SetIsSubscribed(recipient, It.IsAny<bool>())).ReturnsAsync(recipient);
+            userRepoMock.Setup(r => r.SetSubscriptionInfo(recipient, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
+                It.IsAny<int>(), It.IsAny<Instant>())).ReturnsAsync(recipient);
 
-            ISubscriptionProcessor.SubGiftResult subGiftResult = await subscriptionProcessor.ProcessSubscriptionGift(
-                new SubscriptionGiftInfo(user, SubscriptionTier.Tier3, false));
+            SubscriptionInfo subscriptionInfo =
+                new(recipient, 1, 0, SubscriptionTier.Tier3, "Sub Plan Name", Instant.MinValue, "sub message");
+            (ISubscriptionProcessor.SubResult subResult, ISubscriptionProcessor.SubGiftResult subGiftResult) =
+                await subscriptionProcessor.ProcessSubscriptionGift(
+                    new SubscriptionGiftInfo(subscriptionInfo, gifter, false));
 
-            const int expectedTokens = 10 * 5; // 10 per rank. Tier 3 has rank 5 because $25 = 5 * $5
+            const int expectedGiftTokens = 10 * 5; // 10 per rank. Tier 3 has rank 5 because $25 = 5 * $5
             Assert.IsInstanceOf<ISubscriptionProcessor.SubGiftResult.Ok>(subGiftResult);
-            var okResult = (ISubscriptionProcessor.SubGiftResult.Ok)subGiftResult;
-            Assert.AreEqual(expectedTokens, okResult.DeltaTokens);
-            Assert.AreEqual(false, okResult.IsAnonymous);
-            IDictionary<string, object?> expectedData = new Dictionary<string, object?>();
+            var okGiftResult = (ISubscriptionProcessor.SubGiftResult.Ok)subGiftResult;
+            Assert.AreEqual(expectedGiftTokens, okGiftResult.GifterTokens);
+            IDictionary<string, object?> expectedGiftData = new Dictionary<string, object?>();
             bankMock.Verify(b => b.PerformTransaction(
-                new Transaction<User>(user, expectedTokens, "subscription gift", expectedData),
+                new Transaction<User>(gifter, expectedGiftTokens, "subscription gift", expectedGiftData),
                 CancellationToken.None), Times.Once);
+
+            const int expectedSubTokens = 10 + 12 + 14 + 16 + 18; // Tier 3 = 5 ranks with increasing loyalty league
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubResult.Ok>(subResult);
+            var okResult = (ISubscriptionProcessor.SubResult.Ok)subResult;
+            Assert.AreEqual(1, okResult.CumulativeMonths);
+            Assert.AreEqual(expectedSubTokens, okResult.DeltaTokens);
+            Assert.AreEqual(0, okResult.OldLoyaltyLeague);
+            Assert.AreEqual(5, okResult.NewLoyaltyLeague);
+            Assert.IsFalse(okResult.SubCountCorrected);
+            IDictionary<string, object?> expectedSubData = new Dictionary<string, object?>
+            {
+                ["previous_months_subscribed"] = 0,
+                ["new_months_subscribed"] = 1,
+                ["months_difference"] = 1,
+                ["previous_loyalty_tier"] = 0,
+                ["new_loyalty_tier"] = 5,
+                ["loyalty_completions"] = 5,
+            };
+            bankMock.Verify(b => b.PerformTransaction(
+                new Transaction<User>(recipient, expectedSubTokens, "subscription", expectedSubData),
+                CancellationToken.None), Times.Once);
+        }
+
+        [Test]
+        public async Task ignore_duplicate_month_for_sub_gift()
+        {
+            User gifter = MockUser("gifter", monthsSubscribed: 2, SubscriptionTier.Prime, loyaltyLeague: 2);
+            const SubscriptionTier tier = SubscriptionTier.Tier3;
+            User recipient = MockUser("recipient", monthsSubscribed: 1, subscriptionTier: tier, loyaltyLeague: 5);
+            Mock<IBank<User>> bankMock = new();
+            Mock<IUserRepo> userRepoMock = new();
+            ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
+                bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>());
+
+            SubscriptionInfo subscriptionInfo = new(
+                recipient, NumMonths: 1, StreakMonths: 0, tier, "Sub Plan Name", Instant.MinValue, "sub message");
+            (ISubscriptionProcessor.SubResult subResult, ISubscriptionProcessor.SubGiftResult subGiftResult) =
+                await subscriptionProcessor.ProcessSubscriptionGift(
+                    new SubscriptionGiftInfo(subscriptionInfo, gifter, false));
+
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubGiftResult.SameMonth>(subGiftResult);
+            var sameMonthGiftResult = (ISubscriptionProcessor.SubGiftResult.SameMonth)subGiftResult;
+            Assert.AreEqual(1, sameMonthGiftResult.Month);
+            bankMock.VerifyNoOtherCalls();
+
+            Assert.IsInstanceOf<ISubscriptionProcessor.SubResult.SameMonth>(subResult);
+            var sameMonthSubResult = (ISubscriptionProcessor.SubResult.SameMonth)subResult;
+            Assert.AreEqual(1, sameMonthSubResult.Month);
+            bankMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/TPP.Core.Tests/SubscriptionTest.cs
+++ b/TPP.Core.Tests/SubscriptionTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -44,7 +45,7 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
                 new SubscriptionInfo(
                     user, NumMonths: 3, StreakMonths: 2, subscriptionTier, PlanName: "Tier 2",
-                    subscribedAt, Message: "HeyGuys"));
+                    subscribedAt, Message: "HeyGuys", ImmutableList<EmoteOccurrence>.Empty));
 
             // THEN
             const int expectedTokens = 10 + (2 * 4) + 10 + (2 * 5); // per rank: 10 base tokens + 2 tokens per league
@@ -99,7 +100,7 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
                 new SubscriptionInfo(
                     user, NumMonths: 2, StreakMonths: 2, SubscriptionTier.Tier1, PlanName: "Sub Plan Name",
-                    Instant.MinValue, Message: "Repeated"));
+                    Instant.MinValue, Message: "Repeated", ImmutableList<EmoteOccurrence>.Empty));
 
             // THEN
             // negative result
@@ -136,7 +137,7 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor.SubResult subResult = await subscriptionProcessor.ProcessSubscription(
                 new SubscriptionInfo(
                     user, NumMonths: 2, StreakMonths: 2, SubscriptionTier.Tier3, PlanName: "Sub Plan Name",
-                    subscribedAt, Message: "Repeated"));
+                    subscribedAt, Message: "Repeated", ImmutableList<EmoteOccurrence>.Empty));
 
             // THEN
             const int expectedTokens = 14 + 16 + 18 + 20; // Tier 1 -> Tier 3: 4 loyalty completions difference
@@ -184,8 +185,8 @@ namespace TPP.Core.Tests
             userRepoMock.Setup(r => r.SetSubscriptionInfo(recipient, It.IsAny<int>(), It.IsAny<SubscriptionTier>(),
                 It.IsAny<int>(), It.IsAny<Instant>())).ReturnsAsync(recipient);
 
-            SubscriptionInfo subscriptionInfo =
-                new(recipient, 1, 0, SubscriptionTier.Tier3, "Sub Plan Name", Instant.MinValue, "sub message");
+            SubscriptionInfo subscriptionInfo = new(recipient, 1, 0, SubscriptionTier.Tier3, "Sub Plan Name",
+                Instant.MinValue, "sub message", ImmutableList<EmoteOccurrence>.Empty);
             (ISubscriptionProcessor.SubResult subResult, ISubscriptionProcessor.SubGiftResult subGiftResult) =
                 await subscriptionProcessor.ProcessSubscriptionGift(
                     new SubscriptionGiftInfo(subscriptionInfo, gifter, false));
@@ -232,8 +233,8 @@ namespace TPP.Core.Tests
             ISubscriptionProcessor subscriptionProcessor = new SubscriptionProcessor(
                 bankMock.Object, userRepoMock.Object, Mock.Of<ISubscriptionLogRepo>());
 
-            SubscriptionInfo subscriptionInfo = new(
-                recipient, NumMonths: 1, StreakMonths: 0, tier, "Sub Plan Name", Instant.MinValue, "sub message");
+            SubscriptionInfo subscriptionInfo = new(recipient, NumMonths: 1, StreakMonths: 0, tier, "Sub Plan Name",
+                Instant.MinValue, "sub message", ImmutableList<EmoteOccurrence>.Empty);
             (ISubscriptionProcessor.SubResult subResult, ISubscriptionProcessor.SubGiftResult subGiftResult) =
                 await subscriptionProcessor.ProcessSubscriptionGift(
                     new SubscriptionGiftInfo(subscriptionInfo, gifter, false));

--- a/TPP.Core/Chat/ChatFactory.cs
+++ b/TPP.Core/Chat/ChatFactory.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using TPP.Core.Configuration;
+using TPP.Core.Overlay;
 using TPP.Persistence.Models;
 using TPP.Persistence.Repos;
 
@@ -15,10 +16,12 @@ namespace TPP.Core.Chat
         private readonly IBank<User> _tokenBank;
         private readonly ISubscriptionLogRepo _subscriptionLogRepo;
         private readonly ILinkedAccountRepo _linkedAccountRepo;
+        private readonly OverlayConnection _overlayConnection;
 
         public ChatFactory(
             ILoggerFactory loggerFactory, IClock clock, IUserRepo userRepo, IBank<User> tokenBank,
-            ISubscriptionLogRepo subscriptionLogRepo, ILinkedAccountRepo linkedAccountRepo)
+            ISubscriptionLogRepo subscriptionLogRepo, ILinkedAccountRepo linkedAccountRepo,
+            OverlayConnection overlayConnection)
         {
             _loggerFactory = loggerFactory;
             _clock = clock;
@@ -26,6 +29,7 @@ namespace TPP.Core.Chat
             _tokenBank = tokenBank;
             _subscriptionLogRepo = subscriptionLogRepo;
             _linkedAccountRepo = linkedAccountRepo;
+            _overlayConnection = overlayConnection;
         }
 
         public IChat Create(ConnectionConfig config) =>
@@ -33,7 +37,8 @@ namespace TPP.Core.Chat
             {
                 ConnectionConfig.Console cfg => new ConsoleChat(config.Name, _loggerFactory, cfg, _userRepo),
                 ConnectionConfig.Twitch cfg => new TwitchChat(config.Name, _loggerFactory, _clock, cfg, _userRepo,
-                    new SubscriptionProcessor(_tokenBank, _userRepo, _subscriptionLogRepo, _linkedAccountRepo)),
+                    new SubscriptionProcessor(_tokenBank, _userRepo, _subscriptionLogRepo, _linkedAccountRepo),
+                    _overlayConnection),
                 _ => throw new ArgumentOutOfRangeException(nameof(config), "unknown chat connector type")
             };
     }

--- a/TPP.Core/Chat/ChatFactory.cs
+++ b/TPP.Core/Chat/ChatFactory.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using TPP.Core.Configuration;
+using TPP.Persistence.Models;
 using TPP.Persistence.Repos;
 
 namespace TPP.Core.Chat
@@ -11,19 +12,26 @@ namespace TPP.Core.Chat
         private readonly ILoggerFactory _loggerFactory;
         private readonly IClock _clock;
         private readonly IUserRepo _userRepo;
+        private readonly IBank<User> _tokenBank;
+        private readonly ISubscriptionLogRepo _subscriptionLogRepo;
 
-        public ChatFactory(ILoggerFactory loggerFactory, IClock clock, IUserRepo userRepo)
+        public ChatFactory(
+            ILoggerFactory loggerFactory, IClock clock, IUserRepo userRepo, IBank<User> tokenBank,
+            ISubscriptionLogRepo subscriptionLogRepo)
         {
             _loggerFactory = loggerFactory;
             _clock = clock;
             _userRepo = userRepo;
+            _tokenBank = tokenBank;
+            _subscriptionLogRepo = subscriptionLogRepo;
         }
 
         public IChat Create(ConnectionConfig config) =>
             config switch
             {
                 ConnectionConfig.Console cfg => new ConsoleChat(config.Name, _loggerFactory, cfg, _userRepo),
-                ConnectionConfig.Twitch cfg => new TwitchChat(config.Name, _loggerFactory, _clock, cfg, _userRepo),
+                ConnectionConfig.Twitch cfg => new TwitchChat(config.Name, _loggerFactory, _clock, cfg, _userRepo,
+                    new SubscriptionProcessor(_tokenBank, _userRepo, _subscriptionLogRepo)),
                 _ => throw new ArgumentOutOfRangeException(nameof(config), "unknown chat connector type")
             };
     }

--- a/TPP.Core/Chat/ChatFactory.cs
+++ b/TPP.Core/Chat/ChatFactory.cs
@@ -14,16 +14,18 @@ namespace TPP.Core.Chat
         private readonly IUserRepo _userRepo;
         private readonly IBank<User> _tokenBank;
         private readonly ISubscriptionLogRepo _subscriptionLogRepo;
+        private readonly ILinkedAccountRepo _linkedAccountRepo;
 
         public ChatFactory(
             ILoggerFactory loggerFactory, IClock clock, IUserRepo userRepo, IBank<User> tokenBank,
-            ISubscriptionLogRepo subscriptionLogRepo)
+            ISubscriptionLogRepo subscriptionLogRepo, ILinkedAccountRepo linkedAccountRepo)
         {
             _loggerFactory = loggerFactory;
             _clock = clock;
             _userRepo = userRepo;
             _tokenBank = tokenBank;
             _subscriptionLogRepo = subscriptionLogRepo;
+            _linkedAccountRepo = linkedAccountRepo;
         }
 
         public IChat Create(ConnectionConfig config) =>
@@ -31,7 +33,7 @@ namespace TPP.Core.Chat
             {
                 ConnectionConfig.Console cfg => new ConsoleChat(config.Name, _loggerFactory, cfg, _userRepo),
                 ConnectionConfig.Twitch cfg => new TwitchChat(config.Name, _loggerFactory, _clock, cfg, _userRepo,
-                    new SubscriptionProcessor(_tokenBank, _userRepo, _subscriptionLogRepo)),
+                    new SubscriptionProcessor(_tokenBank, _userRepo, _subscriptionLogRepo, _linkedAccountRepo)),
                 _ => throw new ArgumentOutOfRangeException(nameof(config), "unknown chat connector type")
             };
     }

--- a/TPP.Core/Chat/TwitchChat.cs
+++ b/TPP.Core/Chat/TwitchChat.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using TPP.Common;
 using TPP.Core.Configuration;
+using TPP.Core.Overlay.Events;
 using TPP.Persistence.Models;
 using TPP.Persistence.Repos;
 using TwitchLib.Client;
@@ -133,6 +134,13 @@ namespace TPP.Core.Chat
             string response = BuildSubResponse(subResult, null, false);
             await SendWhisper(e.Subscriber, response);
 
+            var evt = new NewSubscriber
+            {
+                User = e.Subscriber,
+                Emotes = ImmutableList<EmoteInfo>.Empty, // TODO emotes
+                SubMessage = e.Message,
+                ShareSub = true,
+            };
             // TODO send to overlay
         }
 
@@ -162,6 +170,13 @@ namespace TPP.Core.Chat
             if (!e.IsAnonymous)
                 await SendWhisper(e.Gifter, subGiftResponse); // don't respond to the "AnAnonymousGifter" user
 
+            var evt = new NewSubscriber
+            {
+                User = e.SubscriptionInfo.Subscriber,
+                Emotes = ImmutableList<EmoteInfo>.Empty, // TODO emotes
+                SubMessage = e.SubscriptionInfo.Message,
+                ShareSub = false,
+            };
             // TODO send to overlay
         }
 

--- a/TPP.Core/Chat/TwitchChat.cs
+++ b/TPP.Core/Chat/TwitchChat.cs
@@ -137,7 +137,7 @@ namespace TPP.Core.Chat
             var evt = new NewSubscriber
             {
                 User = e.Subscriber,
-                Emotes = ImmutableList<EmoteInfo>.Empty, // TODO emotes
+                Emotes = e.Emotes.Select(EmoteInfo.FromOccurence).ToImmutableList(),
                 SubMessage = e.Message,
                 ShareSub = true,
             };
@@ -173,7 +173,7 @@ namespace TPP.Core.Chat
             var evt = new NewSubscriber
             {
                 User = e.SubscriptionInfo.Subscriber,
-                Emotes = ImmutableList<EmoteInfo>.Empty, // TODO emotes
+                Emotes = e.SubscriptionInfo.Emotes.Select(EmoteInfo.FromOccurence).ToImmutableList(),
                 SubMessage = e.SubscriptionInfo.Message,
                 ShareSub = false,
             };

--- a/TPP.Core/Modes/DualcoreMode.cs
+++ b/TPP.Core/Modes/DualcoreMode.cs
@@ -13,16 +13,15 @@ namespace TPP.Core.Modes
         private readonly StopToken _stopToken;
         private readonly ModeBase _modeBase;
         private readonly WebsocketBroadcastServer _broadcastServer;
-        private readonly OverlayConnection _overlayConnection;
 
         public DualcoreMode(ILoggerFactory loggerFactory, BaseConfig baseConfig)
         {
             _logger = loggerFactory.CreateLogger<DualcoreMode>();
             _stopToken = new StopToken();
             Setups.Databases repos = Setups.SetUpRepositories(baseConfig);
-            _modeBase = new ModeBase(loggerFactory, repos, baseConfig, _stopToken);
-
-            (_broadcastServer, _overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
+            OverlayConnection overlayConnection;
+            (_broadcastServer, overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
+            _modeBase = new ModeBase(loggerFactory, repos, baseConfig, _stopToken, overlayConnection);
         }
 
         public async Task Run()

--- a/TPP.Core/Modes/Matchmode.cs
+++ b/TPP.Core/Modes/Matchmode.cs
@@ -38,13 +38,13 @@ namespace TPP.Core.Modes
             _stopToken = new StopToken();
             Setups.Databases repos = Setups.SetUpRepositories(baseConfig);
             _pokeyenBank = repos.PokeyenBank;
-            _modeBase = new ModeBase(loggerFactory, repos, baseConfig, _stopToken);
+            (_broadcastServer, _overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
+
+            _modeBase = new ModeBase(loggerFactory, repos, baseConfig, _stopToken, _overlayConnection);
 
             var bettingCommands = new BettingCommands(() => _bettingPeriod);
             foreach (Command command in bettingCommands.Commands)
                 _modeBase.InstallAdditionalCommand(command);
-
-            (_broadcastServer, _overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
         }
 
         public async Task Run()

--- a/TPP.Core/Modes/ModeBase.cs
+++ b/TPP.Core/Modes/ModeBase.cs
@@ -31,7 +31,8 @@ namespace TPP.Core.Modes
             ArgsParser argsParser = Setups.SetUpArgsParser(repos.UserRepo, pokedexData);
 
             var chats = new Dictionary<string, IChat>();
-            var chatFactory = new ChatFactory(loggerFactory, SystemClock.Instance, repos.UserRepo);
+            var chatFactory = new ChatFactory(loggerFactory, SystemClock.Instance,
+                repos.UserRepo, repos.TokensBank, repos.SubscriptionLogRepo);
             foreach (ConnectionConfig connectorConfig in baseConfig.Chat.Connections)
             {
                 IChat chat = chatFactory.Create(connectorConfig);

--- a/TPP.Core/Modes/ModeBase.cs
+++ b/TPP.Core/Modes/ModeBase.cs
@@ -10,6 +10,7 @@ using TPP.Core.Chat;
 using TPP.Core.Commands;
 using TPP.Core.Commands.Definitions;
 using TPP.Core.Configuration;
+using TPP.Core.Overlay;
 using TPP.Persistence.Repos;
 
 namespace TPP.Core.Modes
@@ -25,14 +26,16 @@ namespace TPP.Core.Modes
         private readonly IClock _clock;
 
         public ModeBase(
-            ILoggerFactory loggerFactory, Setups.Databases repos, BaseConfig baseConfig, StopToken stopToken)
+            ILoggerFactory loggerFactory, Setups.Databases repos, BaseConfig baseConfig, StopToken stopToken,
+            OverlayConnection overlayConnection)
         {
             PokedexData pokedexData = PokedexData.Load();
             ArgsParser argsParser = Setups.SetUpArgsParser(repos.UserRepo, pokedexData);
 
             var chats = new Dictionary<string, IChat>();
             var chatFactory = new ChatFactory(loggerFactory, SystemClock.Instance,
-                repos.UserRepo, repos.TokensBank, repos.SubscriptionLogRepo, repos.LinkedAccountRepo);
+                repos.UserRepo, repos.TokensBank, repos.SubscriptionLogRepo, repos.LinkedAccountRepo,
+                overlayConnection);
             foreach (ConnectionConfig connectorConfig in baseConfig.Chat.Connections)
             {
                 IChat chat = chatFactory.Create(connectorConfig);

--- a/TPP.Core/Modes/ModeBase.cs
+++ b/TPP.Core/Modes/ModeBase.cs
@@ -32,7 +32,7 @@ namespace TPP.Core.Modes
 
             var chats = new Dictionary<string, IChat>();
             var chatFactory = new ChatFactory(loggerFactory, SystemClock.Instance,
-                repos.UserRepo, repos.TokensBank, repos.SubscriptionLogRepo);
+                repos.UserRepo, repos.TokensBank, repos.SubscriptionLogRepo, repos.LinkedAccountRepo);
             foreach (ConnectionConfig connectorConfig in baseConfig.Chat.Connections)
             {
                 IChat chat = chatFactory.Create(connectorConfig);

--- a/TPP.Core/Modes/Runmode.cs
+++ b/TPP.Core/Modes/Runmode.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TPP.Core.Commands.Definitions;
 using TPP.Core.Configuration;
+using TPP.Core.Overlay;
 
 namespace TPP.Core.Modes
 {
@@ -12,6 +13,7 @@ namespace TPP.Core.Modes
         private readonly ILogger<Runmode> _logger;
         private readonly StopToken _stopToken;
         private readonly ModeBase _modeBase;
+        private readonly WebsocketBroadcastServer _broadcastServer;
 
         public Runmode(ILoggerFactory loggerFactory, BaseConfig baseConfig, RunmodeConfig runmodeConfig)
         {
@@ -19,18 +21,23 @@ namespace TPP.Core.Modes
             _logger = loggerFactory.CreateLogger<Runmode>();
             _stopToken = new StopToken();
             Setups.Databases repos = Setups.SetUpRepositories(baseConfig);
-            _modeBase = new ModeBase(loggerFactory, repos, baseConfig, _stopToken);
+            OverlayConnection overlayConnection;
+            (_broadcastServer, overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
+            _modeBase = new ModeBase(loggerFactory, repos, baseConfig, _stopToken, overlayConnection);
         }
 
         public async Task Run()
         {
             _logger.LogInformation("Runmode starting");
             _modeBase.Start();
+            Task overlayWebsocketTask = _broadcastServer.Listen();
             while (!_stopToken.ShouldStop)
             {
                 // TODO run main loop goes here
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
             }
+            await _broadcastServer.Stop();
+            await overlayWebsocketTask;
             _logger.LogInformation("Runmode ended");
         }
 

--- a/TPP.Core/Overlay/Events/SubscriptionEvents.cs
+++ b/TPP.Core/Overlay/Events/SubscriptionEvents.cs
@@ -1,0 +1,27 @@
+using System.Collections.Immutable;
+using System.Runtime.Serialization;
+using TPP.Persistence.Models;
+
+namespace TPP.Core.Overlay.Events
+{
+    [DataContract]
+    public struct EmoteInfo
+    {
+        [DataMember(Name = "id")] public string Id { get; set; }
+        [DataMember(Name = "code")] public string Code { get; set; }
+        [DataMember(Name = "x1")] public string X1 { get; set; }
+        [DataMember(Name = "x2")] public string X2 { get; set; }
+        [DataMember(Name = "x3")] public string X3 { get; set; }
+    }
+
+    [DataContract]
+    public struct NewSubscriber : IOverlayEvent
+    {
+        public string OverlayEventType => "new_subscriber";
+
+        [DataMember(Name = "user")] public User User { get; set; }
+        [DataMember(Name = "message")] public string? SubMessage { get; set; }
+        [DataMember(Name = "emotes")] public IImmutableList<EmoteInfo> Emotes { get; set; }
+        [DataMember(Name = "share_sub")] public bool ShareSub { get; set; }
+    }
+}

--- a/TPP.Core/Overlay/Events/SubscriptionEvents.cs
+++ b/TPP.Core/Overlay/Events/SubscriptionEvents.cs
@@ -12,6 +12,16 @@ namespace TPP.Core.Overlay.Events
         [DataMember(Name = "x1")] public string X1 { get; set; }
         [DataMember(Name = "x2")] public string X2 { get; set; }
         [DataMember(Name = "x3")] public string X3 { get; set; }
+
+        public static EmoteInfo FromOccurence(EmoteOccurrence emote) => new()
+        {
+            Code = emote.Code,
+            Id = emote.Id,
+            // see https://dev.twitch.tv/docs/irc/tags#privmsg-twitch-tags
+            X1 = $"http://static-cdn.jtvnw.net/emoticons/v1/{emote.Id}/1.0",
+            X2 = $"http://static-cdn.jtvnw.net/emoticons/v1/{emote.Id}/2.0",
+            X3 = $"http://static-cdn.jtvnw.net/emoticons/v1/{emote.Id}/3.0",
+        };
     }
 
     [DataContract]

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -95,7 +95,8 @@ namespace TPP.Core
             IBank<User> TokensBank,
             ICommandLogger CommandLogger,
             IMessagequeueRepo MessagequeueRepo,
-            IMessagelogRepo MessagelogRepo
+            IMessagelogRepo MessagelogRepo,
+            ISubscriptionLogRepo SubscriptionLogRepo
         );
 
         public static Databases SetUpRepositories(BaseConfig baseConfig)
@@ -137,7 +138,8 @@ namespace TPP.Core
                 TokensBank: tokenBank,
                 CommandLogger: new CommandLogger(mongoDatabase, clock),
                 MessagequeueRepo: new MessagequeueRepo(mongoDatabase),
-                MessagelogRepo: new MessagelogRepo(mongoDatabaseMessagelog)
+                MessagelogRepo: new MessagelogRepo(mongoDatabaseMessagelog),
+                SubscriptionLogRepo: new SubscriptionLogRepo(mongoDatabase)
             );
         }
     }

--- a/TPP.Core/Subscriptions.cs
+++ b/TPP.Core/Subscriptions.cs
@@ -74,13 +74,16 @@ namespace TPP.Core
         private readonly IBank<User> _tokenBank;
         private readonly IUserRepo _userRepo;
         private readonly ISubscriptionLogRepo _subscriptionLogRepo;
+        private readonly ILinkedAccountRepo _linkedAccountRepo;
 
         public SubscriptionProcessor(
-            IBank<User> tokenBank, IUserRepo userRepo, ISubscriptionLogRepo subscriptionLogRepo)
+            IBank<User> tokenBank, IUserRepo userRepo, ISubscriptionLogRepo subscriptionLogRepo,
+            ILinkedAccountRepo linkedAccountRepo)
         {
             _tokenBank = tokenBank;
             _userRepo = userRepo;
             _subscriptionLogRepo = subscriptionLogRepo;
+            _linkedAccountRepo = linkedAccountRepo;
         }
 
         public async Task<ISubscriptionProcessor.SubResult> ProcessSubscription(SubscriptionInfo subscriptionInfo)
@@ -173,7 +176,10 @@ namespace TPP.Core
         {
             ISubscriptionProcessor.SubResult subResult =
                 await ProcessSubscription(subscriptionGiftInfo.SubscriptionInfo);
-            bool isLinkedAccount = false; // TODO check linked accounts
+            bool isLinkedAccount = await _linkedAccountRepo.AreLinked(
+                subscriptionGiftInfo.Gifter.Id,
+                subscriptionGiftInfo.SubscriptionInfo.Subscriber.Id);
+
             if (isLinkedAccount)
                 return (subResult, new ISubscriptionProcessor.SubGiftResult.LinkedAccount());
 

--- a/TPP.Core/Subscriptions.cs
+++ b/TPP.Core/Subscriptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ using TPP.Persistence.Repos;
 
 namespace TPP.Core
 {
+    public record EmoteOccurrence(string Id, string Code, int StartIndex, int EndIndex);
+
     /// <summary>
     /// Information on a user subscription directly (not via a gift).
     /// Gifted subscriptions are using <see cref="SubscriptionGiftInfo"/> instead.
@@ -21,7 +24,8 @@ namespace TPP.Core
         SubscriptionTier Tier,
         string PlanName,
         Instant SubscriptionAt,
-        string? Message);
+        string? Message,
+        IImmutableList<EmoteOccurrence> Emotes);
 
     /// Information on a user subscribing through a gifted subscription.
     public record SubscriptionGiftInfo(SubscriptionInfo SubscriptionInfo, User Gifter, bool IsAnonymous);

--- a/TPP.Core/Subscriptions.cs
+++ b/TPP.Core/Subscriptions.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using NodaTime;
+using TPP.Common;
+using TPP.Persistence.Models;
+using TPP.Persistence.Repos;
+
+namespace TPP.Core
+{
+    /// Information on a user receiving a subscription (either by subscribing by themselves or getting a gift sub).
+    public record SubscriptionInfo(
+        User Subscriber,
+        int NumMonths,
+        int StreakMonths,
+        SubscriptionTier Tier,
+        string PlanName,
+        Instant SubscriptionAt,
+        string? Message,
+        User? Gifter,
+        bool IsAnonymous);
+
+    /// <summary>
+    /// Information on a user gifting a subscription to another user.
+    /// The subscription itself is described as a separate <see cref="SubscriptionInfo"/> object.
+    /// </summary>
+    public record SubscriptionGiftInfo(
+        User Gifter,
+        SubscriptionTier Tier,
+        bool IsAnonymous);
+
+    public interface ISubscriptionProcessor
+    {
+        public record SubResult
+        {
+            private SubResult()
+            {
+                // Having a private constructor and all subtypes be sealed makes the set of all possible subtypes a
+                // closed set, simulating a sum type.
+            }
+
+            public sealed record Ok(
+                int DeltaTokens,
+                int OldLoyaltyLeague,
+                int NewLoyaltyLeague,
+                int CumulativeMonths,
+                User? Gifter,
+                bool IsAnonymous,
+                bool SubCountCorrected) : SubResult;
+            public sealed record SameMonth(int Month) : SubResult;
+        }
+
+        public record SubGiftResult
+        {
+            private SubGiftResult()
+            {
+                // Having a private constructor and all subtypes be sealed makes the set of all possible subtypes a
+                // closed set, simulating a sum type.
+            }
+
+            /// The gifter successfully received a token reward
+            public sealed record Ok(int DeltaTokens, bool IsAnonymous) : SubGiftResult;
+            /// The gifter is linked to the gift recipient and has not received a token reward
+            public sealed record LinkedAccount(User LinkedUser) : SubGiftResult;
+        }
+
+        Task<SubResult> ProcessSubscription(SubscriptionInfo subscriptionInfo);
+        Task<SubGiftResult> ProcessSubscriptionGift(SubscriptionGiftInfo subscriptionGiftInfo);
+    }
+
+    public class SubscriptionProcessor : ISubscriptionProcessor
+    {
+        private readonly IBank<User> _tokenBank;
+        private readonly IUserRepo _userRepo;
+        private readonly ISubscriptionLogRepo _subscriptionLogRepo;
+
+        public SubscriptionProcessor(
+            IBank<User> tokenBank, IUserRepo userRepo, ISubscriptionLogRepo subscriptionLogRepo)
+        {
+            _tokenBank = tokenBank;
+            _userRepo = userRepo;
+            _subscriptionLogRepo = subscriptionLogRepo;
+        }
+
+        public async Task<ISubscriptionProcessor.SubResult> ProcessSubscription(SubscriptionInfo subscriptionInfo)
+        {
+            User user = subscriptionInfo.Subscriber;
+            if (user.MonthsSubscribed == subscriptionInfo.NumMonths &&
+                user.SubscriptionTier?.ToRank() >= subscriptionInfo.Tier.ToRank())
+            {
+                // If twitch reports the new months as being the same as the old months, such as due to repeated message
+                // or other error, ignore the sub but send a warning to the user in case of issues.
+                return new ISubscriptionProcessor.SubResult.SameMonth(subscriptionInfo.NumMonths);
+            }
+
+            bool subCountCorrected = false;
+            if (user.MonthsSubscribed > subscriptionInfo.NumMonths)
+            {
+                // Repair the user data and re-read it for further processing.
+                // Set to current months - 1 to process as a 1-month subscription further down.
+                user = await _userRepo.SetSubscriptionInfo(
+                    user, subscriptionInfo.NumMonths - 1, subscriptionInfo.Tier, user.LoyaltyLeague,
+                    user.SubscriptionUpdatedAt);
+                subCountCorrected = true;
+            }
+            // If our internal months subscribed count is less than what Twitch says it is,
+            // we update our count and give the subscriber "back pay" tokens.
+            // This can occur when users (re)subscribe while the tpp bot is down.
+
+            Debug.Assert(subscriptionInfo.NumMonths > user.MonthsSubscribed ||
+                         (subscriptionInfo.NumMonths == user.MonthsSubscribed &&
+                          subscriptionInfo.Tier.ToRank() > user.SubscriptionTier!.Value.ToRank()));
+
+            // Difference between previous recorded subscribed months and new amount.
+            int monthsDifference = subscriptionInfo.NumMonths - user.MonthsSubscribed;
+            int loyaltyCompletions;
+            if (monthsDifference > 0)
+            {
+                // Additional benefits for expensive plans are given only for the current months to prevent users from
+                // tricking us into giving them extra "back pay", e.g. by purposefully not announcing lower grade
+                // subscriptions from previous months.
+                loyaltyCompletions = monthsDifference - 1 + subscriptionInfo.Tier.ToRank();
+            }
+            else
+            {
+                Debug.Assert(user.SubscriptionTier.HasValue,
+                    "no months difference must mean it's a tier upgrade, so the user has subscribed before");
+                // Same month, but an upgrade in subscription tier. Pay the difference in monetary rank.
+                loyaltyCompletions = subscriptionInfo.Tier.ToRank() - user.SubscriptionTier.Value.ToRank();
+            }
+
+            const int maxLeague = 15;
+            const int tokensPerLeague = 2;
+            const int baseTokens = 10;
+            int newLoyaltyLeague = Math.Min(user.LoyaltyLeague + loyaltyCompletions, maxLeague);
+            int tokens = Enumerable
+                .Range(user.LoyaltyLeague, loyaltyCompletions)
+                .Select(league => baseTokens + Math.Min(league, maxLeague) * tokensPerLeague)
+                .Sum();
+            int oldLoyaltyLeague = user.LoyaltyLeague;
+
+            SubscriptionLog subscriptionLog = await _subscriptionLogRepo.LogSubscription(
+                user.Id, subscriptionInfo.SubscriptionAt,
+                subscriptionInfo.StreakMonths, user.MonthsSubscribed, subscriptionInfo.NumMonths, monthsDifference,
+                oldLoyaltyLeague, newLoyaltyLeague, loyaltyCompletions, tokens,
+                subscriptionInfo.Message, subscriptionInfo.Tier, subscriptionInfo.PlanName);
+
+            TransactionLog transactionLog = await _tokenBank.PerformTransaction(new Transaction<User>(
+                user, tokens, TransactionType.Subscription, new Dictionary<string, object?>
+                {
+                    ["previous_months_subscribed"] = user.MonthsSubscribed,
+                    ["new_months_subscribed"] = subscriptionInfo.NumMonths,
+                    ["months_difference"] = monthsDifference,
+                    ["previous_loyalty_tier"] = oldLoyaltyLeague,
+                    ["new_loyalty_tier"] = newLoyaltyLeague,
+                    ["loyalty_completions"] = loyaltyCompletions
+                }));
+            user = await _userRepo.SetIsSubscribed(user, true);
+            user = await _userRepo.SetSubscriptionInfo(
+                user, subscriptionInfo.NumMonths, subscriptionInfo.Tier, newLoyaltyLeague,
+                subscriptionInfo.SubscriptionAt);
+            return new ISubscriptionProcessor.SubResult.Ok(
+                DeltaTokens: tokens,
+                OldLoyaltyLeague: oldLoyaltyLeague,
+                NewLoyaltyLeague: newLoyaltyLeague,
+                CumulativeMonths: subscriptionInfo.NumMonths,
+                Gifter: subscriptionInfo.Gifter,
+                IsAnonymous: subscriptionInfo.IsAnonymous,
+                SubCountCorrected: subCountCorrected);
+        }
+
+        public async Task<ISubscriptionProcessor.SubGiftResult> ProcessSubscriptionGift(
+            SubscriptionGiftInfo subscriptionGiftInfo)
+        {
+            // TODO check linked accounts
+
+            const int tokensPerRank = 10;
+            int rewardTokens = subscriptionGiftInfo.Tier.ToRank() * tokensPerRank;
+            TransactionLog transactionLog = await _tokenBank.PerformTransaction(new Transaction<User>(
+                subscriptionGiftInfo.Gifter,
+                rewardTokens,
+                TransactionType.SubscriptionGift
+            ));
+
+            return new ISubscriptionProcessor.SubGiftResult.Ok(rewardTokens, subscriptionGiftInfo.IsAnonymous);
+        }
+    }
+}

--- a/TPP.Core/TwitchLibSubscriptionWatcher.cs
+++ b/TPP.Core/TwitchLibSubscriptionWatcher.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using NodaTime;
 using TPP.Common;
@@ -70,7 +72,7 @@ namespace TPP.Core
             SubscriptionInfo subscriptionInfo = new(
                 user, int.Parse(subscriptionMessage.MsgParamMonths), StreakMonths: 1, tier,
                 subscriptionMessage.MsgParamSubPlanName, _clock.GetCurrentInstant(),
-                Message: null);
+                Message: null, ParseEmotes(e.GiftedSubscription.Emotes));
             SubscriptionGiftInfo subscriptionGiftInfo = new(subscriptionInfo, gifter, subscriptionMessage.IsAnonymous);
             SubscriptionGifted?.Invoke(this, subscriptionGiftInfo);
         }
@@ -99,8 +101,14 @@ namespace TPP.Core
             if (!int.TryParse(subscriptionMessage.MsgParamStreakMonths, out int streakMonths)) streakMonths = 1;
             return new SubscriptionInfo(
                 user, int.Parse(subscriptionMessage.MsgParamCumulativeMonths), streakMonths, tier,
-                subscriptionMessage.SubscriptionPlanName, _clock.GetCurrentInstant(), message);
+                subscriptionMessage.SubscriptionPlanName, _clock.GetCurrentInstant(), message,
+                ParseEmotes(subscriptionMessage.EmoteSet));
         }
+
+        private static IImmutableList<EmoteOccurrence> ParseEmotes(string emoteString) =>
+            new EmoteSet(emoteString, string.Empty).Emotes
+                .Select(e => new EmoteOccurrence(e.Id, e.Name, e.StartIndex, e.EndIndex))
+                .ToImmutableList();
 
         public void Dispose()
         {

--- a/TPP.Core/TwitchLibSubscriptionWatcher.cs
+++ b/TPP.Core/TwitchLibSubscriptionWatcher.cs
@@ -70,9 +70,8 @@ namespace TPP.Core
             SubscriptionInfo subscriptionInfo = new(
                 user, int.Parse(subscriptionMessage.MsgParamMonths), StreakMonths: 1, tier,
                 subscriptionMessage.MsgParamSubPlanName, _clock.GetCurrentInstant(),
-                Message: null, gifter, subscriptionMessage.IsAnonymous);
-            SubscriptionGiftInfo subscriptionGiftInfo = new(gifter, tier, subscriptionMessage.IsAnonymous);
-            Subscribed?.Invoke(this, subscriptionInfo);
+                Message: null);
+            SubscriptionGiftInfo subscriptionGiftInfo = new(subscriptionInfo, gifter, subscriptionMessage.IsAnonymous);
             SubscriptionGifted?.Invoke(this, subscriptionGiftInfo);
         }
 
@@ -100,8 +99,7 @@ namespace TPP.Core
             if (!int.TryParse(subscriptionMessage.MsgParamStreakMonths, out int streakMonths)) streakMonths = 1;
             return new SubscriptionInfo(
                 user, int.Parse(subscriptionMessage.MsgParamCumulativeMonths), streakMonths, tier,
-                subscriptionMessage.SubscriptionPlanName, _clock.GetCurrentInstant(),
-                message, Gifter: null, IsAnonymous: false);
+                subscriptionMessage.SubscriptionPlanName, _clock.GetCurrentInstant(), message);
         }
 
         public void Dispose()

--- a/TPP.Core/TwitchLibSubscriptionWatcher.cs
+++ b/TPP.Core/TwitchLibSubscriptionWatcher.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using NodaTime;
+using TPP.Common;
+using TPP.Persistence.Models;
+using TPP.Persistence.Repos;
+using TwitchLib.Client;
+using TwitchLib.Client.Enums;
+using TwitchLib.Client.Events;
+using TwitchLib.Client.Models;
+
+namespace TPP.Core
+{
+    public sealed class TwitchLibSubscriptionWatcher : IDisposable
+    {
+        private readonly IUserRepo _userRepo;
+        private readonly TwitchClient _twitchClient;
+        private readonly IClock _clock;
+
+        public event EventHandler<SubscriptionInfo>? Subscribed;
+        public event EventHandler<SubscriptionGiftInfo>? SubscriptionGifted;
+
+        public TwitchLibSubscriptionWatcher(
+            IUserRepo userRepo, TwitchClient twitchClient, IClock clock)
+        {
+            _userRepo = userRepo;
+            _twitchClient = twitchClient;
+            _clock = clock;
+            _twitchClient.OnNewSubscriber += OnNewSubscriber;
+            _twitchClient.OnReSubscriber += OnReSubscriber;
+            _twitchClient.OnGiftedSubscription += OnGiftedSubscription;
+        }
+
+        private async void OnNewSubscriber(object? sender, OnNewSubscriberArgs e)
+        {
+            SubscriptionInfo subscriptionInfo = await ParseSubscription(e.Subscriber);
+            Subscribed?.Invoke(this, subscriptionInfo);
+        }
+
+        private async void OnReSubscriber(object? sender, OnReSubscriberArgs e)
+        {
+            SubscriptionInfo subscriptionInfo = await ParseSubscription(e.ReSubscriber);
+            Subscribed?.Invoke(this, subscriptionInfo);
+        }
+
+        private async void OnGiftedSubscription(object? sender, OnGiftedSubscriptionArgs e)
+        {
+            GiftedSubscription subscriptionMessage = e.GiftedSubscription;
+            User gifter = await _userRepo.RecordUser(new UserInfo(
+                subscriptionMessage.UserId,
+                subscriptionMessage.DisplayName,
+                subscriptionMessage.Login
+            ));
+            User user = await _userRepo.RecordUser(new UserInfo(
+                subscriptionMessage.MsgParamRecipientId,
+                subscriptionMessage.MsgParamRecipientDisplayName,
+                subscriptionMessage.MsgParamRecipientUserName
+            ));
+            SubscriptionTier tier = subscriptionMessage.MsgParamSubPlan switch
+            {
+                SubscriptionPlan.Prime => SubscriptionTier.Prime,
+                SubscriptionPlan.Tier1 => SubscriptionTier.Tier1,
+                SubscriptionPlan.Tier2 => SubscriptionTier.Tier2,
+                SubscriptionPlan.Tier3 => SubscriptionTier.Tier3,
+                SubscriptionPlan.NotSet => throw new ArgumentOutOfRangeException(
+                    $"subscription plan not set, plan name: {subscriptionMessage.MsgParamSubPlanName}"),
+                _ => throw new ArgumentOutOfRangeException(
+                    $"unknown subscription plan '{subscriptionMessage.MsgParamSubPlan}'")
+            };
+            SubscriptionInfo subscriptionInfo = new(
+                user, int.Parse(subscriptionMessage.MsgParamMonths), StreakMonths: 1, tier,
+                subscriptionMessage.MsgParamSubPlanName, _clock.GetCurrentInstant(),
+                Message: null, gifter, subscriptionMessage.IsAnonymous);
+            SubscriptionGiftInfo subscriptionGiftInfo = new(gifter, tier, subscriptionMessage.IsAnonymous);
+            Subscribed?.Invoke(this, subscriptionInfo);
+            SubscriptionGifted?.Invoke(this, subscriptionGiftInfo);
+        }
+
+        private async Task<SubscriptionInfo> ParseSubscription(SubscriberBase subscriptionMessage)
+        {
+            User user = await _userRepo.RecordUser(new UserInfo(
+                subscriptionMessage.UserId,
+                subscriptionMessage.DisplayName,
+                subscriptionMessage.Login
+            ));
+            SubscriptionTier tier = subscriptionMessage.SubscriptionPlan switch
+            {
+                SubscriptionPlan.Prime => SubscriptionTier.Prime,
+                SubscriptionPlan.Tier1 => SubscriptionTier.Tier1,
+                SubscriptionPlan.Tier2 => SubscriptionTier.Tier2,
+                SubscriptionPlan.Tier3 => SubscriptionTier.Tier3,
+                SubscriptionPlan.NotSet => throw new ArgumentOutOfRangeException(
+                    $"subscription plan not set, plan name: {subscriptionMessage.SubscriptionPlanName}"),
+                _ => throw new ArgumentOutOfRangeException(
+                    $"unknown subscription plan '{subscriptionMessage.SubscriptionPlan}'")
+            };
+            string? message = string.IsNullOrWhiteSpace(subscriptionMessage.ResubMessage)
+                ? null
+                : subscriptionMessage.ResubMessage;
+            if (!int.TryParse(subscriptionMessage.MsgParamStreakMonths, out int streakMonths)) streakMonths = 1;
+            return new SubscriptionInfo(
+                user, int.Parse(subscriptionMessage.MsgParamCumulativeMonths), streakMonths, tier,
+                subscriptionMessage.SubscriptionPlanName, _clock.GetCurrentInstant(),
+                message, Gifter: null, IsAnonymous: false);
+        }
+
+        public void Dispose()
+        {
+            _twitchClient.OnNewSubscriber -= OnNewSubscriber;
+            _twitchClient.OnReSubscriber -= OnReSubscriber;
+            _twitchClient.OnGiftedSubscription -= OnGiftedSubscription;
+        }
+    }
+}

--- a/TPP.Persistence.MongoDB.Tests/Repos/SubscriptionLogRepoTest.cs
+++ b/TPP.Persistence.MongoDB.Tests/Repos/SubscriptionLogRepoTest.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using NodaTime;
+using NUnit.Framework;
+using TPP.Common;
+using TPP.Persistence.Models;
+using TPP.Persistence.MongoDB.Repos;
+
+namespace TPP.Persistence.MongoDB.Tests.Repos
+{
+    public class SubscriptionLogRepoTest : MongoTestBase
+    {
+        [Test]
+        public async Task persists_successfully()
+        {
+            SubscriptionLogRepo repo = new(CreateTemporaryDatabase());
+            Instant timestamp = Instant.FromUnixTimeSeconds(123);
+            const string userId = "123";
+            const int monthsStreak = 101;
+            const int monthsNumPrev = 103;
+            const int monthsNumNew = 105;
+            const int monthsDifference = 2;
+            const int loyaltyLeaguePrev = 20;
+            const int loyaltyLeagueNew = 21;
+            const int loyaltyCompletions = 1;
+            const int rewardTokens = 10;
+            const string subMessage = "message text";
+            const SubscriptionTier subPlan = SubscriptionTier.Tier2;
+            const string subPlanName = "plan name";
+
+            // persist to db
+            SubscriptionLog written = await repo.LogSubscription(userId, timestamp,
+                monthsStreak, monthsNumPrev, monthsNumNew, monthsDifference,
+                loyaltyLeaguePrev, loyaltyLeagueNew, loyaltyCompletions, rewardTokens,
+                subMessage, subPlan, subPlanName);
+            Assert.AreEqual(timestamp, written.Timestamp);
+            Assert.AreEqual(userId, written.UserId);
+            Assert.AreEqual(monthsStreak, written.MonthsStreak);
+            Assert.AreEqual(monthsNumPrev, written.MonthsNumPrev);
+            Assert.AreEqual(monthsNumNew, written.MonthsNumNew);
+            Assert.AreEqual(monthsDifference, written.MonthsDifference);
+            Assert.AreEqual(loyaltyLeaguePrev, written.LoyaltyLeaguePrev);
+            Assert.AreEqual(loyaltyLeagueNew, written.LoyaltyLeagueNew);
+            Assert.AreEqual(loyaltyCompletions, written.LoyaltyCompletions);
+            Assert.AreEqual(rewardTokens, written.RewardTokens);
+            Assert.AreEqual(subMessage, written.SubMessage);
+            Assert.AreEqual(subPlan, written.SubPlan);
+            Assert.AreEqual(subPlanName, written.SubPlanName);
+            Assert.NotNull(written.Id);
+
+            // read from db
+            List<SubscriptionLog> allItems = await repo.Collection.Find(FilterDefinition<SubscriptionLog>.Empty).ToListAsync();
+            Assert.AreEqual(1, allItems.Count);
+            SubscriptionLog read = allItems[0];
+            Assert.AreEqual(written, read);
+
+            Assert.AreEqual(timestamp, read.Timestamp);
+            Assert.AreEqual(userId, read.UserId);
+            Assert.AreEqual(monthsStreak, read.MonthsStreak);
+            Assert.AreEqual(monthsNumPrev, read.MonthsNumPrev);
+            Assert.AreEqual(monthsNumNew, read.MonthsNumNew);
+            Assert.AreEqual(monthsDifference, read.MonthsDifference);
+            Assert.AreEqual(loyaltyLeaguePrev, read.LoyaltyLeaguePrev);
+            Assert.AreEqual(loyaltyLeagueNew, read.LoyaltyLeagueNew);
+            Assert.AreEqual(loyaltyCompletions, read.LoyaltyCompletions);
+            Assert.AreEqual(rewardTokens, read.RewardTokens);
+            Assert.AreEqual(subMessage, read.SubMessage);
+            Assert.AreEqual(subPlan, read.SubPlan);
+            Assert.AreEqual(subPlanName, read.SubPlanName);
+        }
+    }
+}

--- a/TPP.Persistence.MongoDB.Tests/Repos/UserRepoTest.cs
+++ b/TPP.Persistence.MongoDB.Tests/Repos/UserRepoTest.cs
@@ -164,7 +164,7 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
             var userInfo = new UserInfo("123", "X", "x", null);
             await userRepo.RecordUser(userInfo);
             UpdateResult updateResult = await userRepo.Collection.UpdateOneAsync(u => u.Id == userInfo.Id,
-                    Builders<User>.Update.Unset(u => u.ParticipationEmblems));
+                Builders<User>.Update.Unset(u => u.ParticipationEmblems));
             Assert.AreEqual(1, updateResult.ModifiedCount);
 
             // when
@@ -205,6 +205,36 @@ namespace TPP.Persistence.MongoDB.Tests.Repos
             Assert.AreNotSame(userFromReading!, userFromRecording);
             Assert.AreEqual(pokeyen, userFromReading!.Pokeyen);
             Assert.AreEqual(tokens, userFromReading!.Tokens);
+        }
+
+        [Test]
+        public async Task set_is_subscribed()
+        {
+            IUserRepo userRepo = new UserRepo(CreateTemporaryDatabase(), 0, 0);
+
+            User userBeforeUpdate = await userRepo.RecordUser(new UserInfo("123", "X", "x"));
+            Assert.IsFalse(userBeforeUpdate.IsSubscribed);
+            User userAfterUpdate = await userRepo.SetIsSubscribed(userBeforeUpdate, true);
+            Assert.IsTrue(userAfterUpdate.IsSubscribed);
+        }
+
+        [Test]
+        public async Task set_subscription_info()
+        {
+            IUserRepo userRepo = new UserRepo(CreateTemporaryDatabase(), 0, 0);
+
+            User userBeforeUpdate = await userRepo.RecordUser(new UserInfo("123", "X", "x"));
+            Assert.AreEqual(0, userBeforeUpdate.MonthsSubscribed);
+            Assert.IsNull(userBeforeUpdate.SubscriptionTier);
+            Assert.AreEqual(0, userBeforeUpdate.LoyaltyLeague);
+            Assert.IsNull(userBeforeUpdate.SubscriptionUpdatedAt);
+
+            User userAfterUpdate = await userRepo.SetSubscriptionInfo(userBeforeUpdate,
+                42, SubscriptionTier.Tier2, 10, Instant.FromUnixTimeSeconds(123));
+            Assert.AreEqual(42, userAfterUpdate.MonthsSubscribed);
+            Assert.AreEqual(SubscriptionTier.Tier2, userAfterUpdate.SubscriptionTier);
+            Assert.AreEqual(10, userAfterUpdate.LoyaltyLeague);
+            Assert.AreEqual(Instant.FromUnixTimeSeconds(123), userAfterUpdate.SubscriptionUpdatedAt);
         }
     }
 }

--- a/TPP.Persistence.MongoDB/Repos/SubscriptionLogRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/SubscriptionLogRepo.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.IdGenerators;
+using MongoDB.Driver;
+using NodaTime;
+using TPP.Common;
+using TPP.Persistence.Models;
+using TPP.Persistence.MongoDB.Serializers;
+using TPP.Persistence.Repos;
+
+namespace TPP.Persistence.MongoDB.Repos
+{
+    public class SubscriptionLogRepo : ISubscriptionLogRepo
+    {
+        public const string CollectionName = "subscriptionlog";
+
+        public readonly IMongoCollection<SubscriptionLog> Collection;
+
+        static SubscriptionLogRepo()
+        {
+            BsonClassMap.RegisterClassMap<SubscriptionLog>(cm =>
+            {
+                cm.MapIdProperty(i => i.Id)
+                    .SetIdGenerator(StringObjectIdGenerator.Instance)
+                    .SetSerializer(ObjectIdAsStringSerializer.Instance);
+                cm.MapProperty(i => i.UserId).SetElementName("user_id");
+                cm.MapProperty(i => i.Timestamp).SetElementName("timestamp");
+                cm.MapProperty(i => i.MonthsStreak).SetElementName("months_in_a_row");
+                cm.MapProperty(i => i.MonthsNumPrev).SetElementName("previous_months_subscribed");
+                cm.MapProperty(i => i.MonthsNumNew).SetElementName("new_months_subscribed");
+                cm.MapProperty(i => i.MonthsDifference).SetElementName("difference");
+                cm.MapProperty(i => i.LoyaltyLeaguePrev).SetElementName("previous_loyalty_tier");
+                cm.MapProperty(i => i.LoyaltyLeagueNew).SetElementName("new_loyalty_tier");
+                cm.MapProperty(i => i.LoyaltyCompletions).SetElementName("loyalty_completions");
+                cm.MapProperty(i => i.RewardTokens).SetElementName("tokens");
+                cm.MapProperty(i => i.SubMessage).SetElementName("message");
+                cm.MapProperty(i => i.SubPlan).SetElementName("plan");
+                cm.MapProperty(i => i.SubPlanName).SetElementName("plan_name");
+            });
+        }
+
+        public SubscriptionLogRepo(IMongoDatabase database)
+        {
+            database.CreateCollectionIfNotExists(CollectionName).Wait();
+            Collection = database.GetCollection<SubscriptionLog>(CollectionName);
+        }
+
+        public async Task<SubscriptionLog> LogSubscription(
+            string userId, Instant timestamp, int monthsStreak, int monthsNumPrev,
+            int monthsNumNew, int monthsDifference, int loyaltyLeaguePrev, int loyaltyLeagueNew, int loyaltyCompletions,
+            int rewardTokens, string? subMessage, SubscriptionTier subPlan, string subPlanName)
+        {
+            var item = new SubscriptionLog(
+                string.Empty, userId, timestamp,
+                monthsStreak, monthsNumPrev, monthsNumNew, monthsDifference,
+                loyaltyLeaguePrev, loyaltyLeagueNew, loyaltyCompletions, rewardTokens,
+                subMessage, subPlan, subPlanName);
+            await Collection.InsertOneAsync(item);
+            Debug.Assert(item.Id.Length > 0, "The MongoDB driver injected a generated ID");
+            return item;
+        }
+    }
+}

--- a/TPP.Persistence.MongoDB/Repos/UserRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/UserRepo.cs
@@ -44,6 +44,14 @@ namespace TPP.Persistence.MongoDB.Repos
                 cm.MapProperty(u => u.GlowColor).SetElementName("secondary_color");
                 cm.MapProperty(u => u.GlowColorUnlocked).SetElementName("secondary_color_unlocked");
                 cm.MapProperty(u => u.PokeyenBetRank).SetElementName("pokeyen_bet_rank");
+                cm.MapProperty(u => u.IsSubscribed).SetElementName("subscriber");
+                cm.MapProperty(u => u.MonthsSubscribed).SetElementName("months_subscribed")
+                    // 0 instead of null in code, but may be omitted in the database
+                    .SetDefaultValue(0)
+                    .SetIgnoreIfDefault(true);
+                cm.MapProperty(u => u.SubscriptionTier).SetElementName("sub_plan");
+                cm.MapProperty(u => u.LoyaltyLeague).SetElementName("loyalty_tier");
+                cm.MapProperty(u => u.SubscriptionUpdatedAt).SetElementName("subscription_updated_at");
             });
         }
 
@@ -166,5 +174,25 @@ namespace TPP.Persistence.MongoDB.Repos
                 update: Builders<User>.Update.Set(u => u.SelectedBadge, null),
                 options: new FindOneAndUpdateOptions<User> { ReturnDocument = ReturnDocument.After, IsUpsert = false })
             != null;
+
+        public Task<User> SetIsSubscribed(User user, bool isSubscribed) =>
+            UpdateField(user, u => u.IsSubscribed, isSubscribed);
+
+        public async Task<User> SetSubscriptionInfo(User user,
+            int monthsSubscribed, SubscriptionTier tier, int loyaltyLeague, Instant? subscriptionUpdatedAt)
+            =>
+                await Collection.FindOneAndUpdateAsync<User>(
+                    filter: u => u.Id == user.Id,
+                    update: Builders<User>.Update
+                        .Set(u => u.MonthsSubscribed, monthsSubscribed)
+                        .Set(u => u.SubscriptionTier, tier)
+                        .Set(u => u.LoyaltyLeague, loyaltyLeague)
+                        .Set(u => u.SubscriptionUpdatedAt, subscriptionUpdatedAt),
+                    options: new FindOneAndUpdateOptions<User>
+                    {
+                        ReturnDocument = ReturnDocument.After,
+                        IsUpsert = false
+                    })
+                ?? throw new ArgumentException($"user {user} does not exist");
     }
 }

--- a/TPP.Persistence.MongoDB/Serializers/CustomSerializers.cs
+++ b/TPP.Persistence.MongoDB/Serializers/CustomSerializers.cs
@@ -18,6 +18,7 @@ namespace TPP.Persistence.MongoDB.Serializers
             BsonSerializer.RegisterSerializer(PkmnSpeciesSerializer.Instance);
             BsonSerializer.RegisterSerializer(InstantSerializer.Instance);
             BsonSerializer.RegisterSerializer(NullableInstantSerializer.Instance);
+            BsonSerializer.RegisterSerializer(SubscriptionTierSerializer.Instance);
         }
     }
 }

--- a/TPP.Persistence.MongoDB/Serializers/SubscriptionTierSerializer.cs
+++ b/TPP.Persistence.MongoDB/Serializers/SubscriptionTierSerializer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using TPP.Common;
+
+namespace TPP.Persistence.MongoDB.Serializers
+{
+    public class SubscriptionTierSerializer : EnumToStringUsingTranslationMappingSerializer<SubscriptionTier>
+    {
+        public static readonly SubscriptionTierSerializer Instance = new();
+
+        public SubscriptionTierSerializer() : base(new Dictionary<SubscriptionTier, string>
+        {
+            [SubscriptionTier.Prime] = "Prime",
+            [SubscriptionTier.Tier1] = "1000",
+            [SubscriptionTier.Tier2] = "2000",
+            [SubscriptionTier.Tier3] = "3000",
+        })
+        {
+        }
+    }
+}

--- a/TPP.Persistence/Models/SubscriptionLog.cs
+++ b/TPP.Persistence/Models/SubscriptionLog.cs
@@ -1,0 +1,21 @@
+using NodaTime;
+using TPP.Common;
+
+namespace TPP.Persistence.Models
+{
+    public record SubscriptionLog(
+        string Id,
+        string UserId,
+        Instant Timestamp,
+        int MonthsStreak,
+        int MonthsNumPrev,
+        int MonthsNumNew,
+        int MonthsDifference,
+        int LoyaltyLeaguePrev,
+        int LoyaltyLeagueNew,
+        int LoyaltyCompletions,
+        int RewardTokens,
+        string? SubMessage,
+        SubscriptionTier SubPlan,
+        string SubPlanName);
+}

--- a/TPP.Persistence/Models/User.cs
+++ b/TPP.Persistence/Models/User.cs
@@ -34,7 +34,6 @@ namespace TPP.Persistence.Models
         public Instant FirstActiveAt { get; init; }
         public Instant LastActiveAt { get; init; }
         // public Instant? FollowedAt { get; init; }
-        // public Instant? SubscriptionUpdatedAt { get; init; }
         // public Instant? LastBetAt { get; init; }
         public Instant? LastMessageAt { get; init; }
 
@@ -53,17 +52,18 @@ namespace TPP.Persistence.Models
 
         // public bool Active { get; init; }
         // public bool Follower { get; init; }
-        // public bool Subscriber { get; init; }
-        // public bool Turbo { get; init; }
         // public List<string> Badges { get; init; } // twitch badges, e.g. subscriber/24
         // public Dictionary<string, string> Milestones { get; init; }
 
-        // public int MonthsSubscribed { get; init; }
+        public bool IsSubscribed { get; init; }
+        public int MonthsSubscribed { get; init; }
+        public SubscriptionTier? SubscriptionTier { get; init; }
+        public int LoyaltyLeague { get; init; }
+        public Instant? SubscriptionUpdatedAt { get; init; }
         // public int RankedPokeyen { get; init; } // wtf is this used for?
         // public int PreviousPokeyenBetRank { get; init; } // wtf is this used for?
         // public int PokeyenBetRankVersion { get; init; } // wtf is this used for?
 
-        // public int LoyaltyTier { get; init; }
         // TODO unlocked items?
 
         // public bool Imported { get; init; }
@@ -84,7 +84,12 @@ namespace TPP.Persistence.Models
             PkmnSpecies? selectedBadge = null,
             string? glowColor = null,
             bool glowColorUnlocked = false,
-            int? pokeyenBetRank = null)
+            int? pokeyenBetRank = null,
+            bool isSubscribed = false,
+            int monthsSubscribed = 0,
+            SubscriptionTier? subscriptionTier = null,
+            int loyaltyLeague = 0,
+            Instant? subscriptionUpdatedAt = null)
         {
             Id = id;
             TwitchDisplayName = twitchDisplayName;
@@ -102,6 +107,11 @@ namespace TPP.Persistence.Models
             GlowColor = glowColor;
             GlowColorUnlocked = glowColorUnlocked;
             PokeyenBetRank = pokeyenBetRank;
+            IsSubscribed = isSubscribed;
+            MonthsSubscribed = monthsSubscribed;
+            SubscriptionTier = subscriptionTier;
+            LoyaltyLeague = loyaltyLeague;
+            SubscriptionUpdatedAt = subscriptionUpdatedAt;
         }
 
         public override string ToString() => $"User({Id}/{SimpleName})";

--- a/TPP.Persistence/Repos/IBank.cs
+++ b/TPP.Persistence/Repos/IBank.cs
@@ -28,6 +28,8 @@ namespace TPP.Persistence.Repos
         public const string ManualAdjustment = "manual_adjustment";
         public const string DonationGive = "donation_give";
         public const string DonationReceive = "donation_recieve"; // typo kept for backwards-compatibility for now
+        public const string Subscription = "subscription";
+        public const string SubscriptionGift = "subscription gift";
 
         // collect all the types being used here instead of scattering string literals across the codebase
     }
@@ -59,7 +61,7 @@ namespace TPP.Persistence.Repos
             T user,
             long change,
             string type,
-            IDictionary<string, object?>? additionalData = default)
+            IDictionary<string, object?>? additionalData = null)
         {
             User = user;
             Change = change;

--- a/TPP.Persistence/Repos/ISubscriptionLogRepo.cs
+++ b/TPP.Persistence/Repos/ISubscriptionLogRepo.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using NodaTime;
+using TPP.Common;
+using TPP.Persistence.Models;
+
+namespace TPP.Persistence.Repos
+{
+    public interface ISubscriptionLogRepo
+    {
+        Task<SubscriptionLog> LogSubscription(
+            string userId,
+            Instant timestamp,
+            int monthsStreak,
+            int monthsNumPrev,
+            int monthsNumNew,
+            int monthsDifference,
+            int loyaltyLeaguePrev,
+            int loyaltyLeagueNew,
+            int loyaltyCompletions,
+            int rewardTokens,
+            string? subMessage,
+            SubscriptionTier subPlan,
+            string subPlanName);
+    }
+}

--- a/TPP.Persistence/Repos/IUserRepo.cs
+++ b/TPP.Persistence/Repos/IUserRepo.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using NodaTime;
 using TPP.Common;
 using TPP.Persistence.Models;
 
@@ -14,6 +15,10 @@ namespace TPP.Persistence.Repos
         public Task<User> SetGlowColor(User user, string? glowColor);
         public Task<User> SetGlowColorUnlocked(User user, bool unlocked);
         public Task<User> SetDisplayName(User user, string displayName);
+
+        public Task<User> SetIsSubscribed(User user, bool isSubscribed);
+        public Task<User> SetSubscriptionInfo(
+            User user, int monthsSubscribed, SubscriptionTier tier, int loyaltyLeague, Instant? subscriptionUpdatedAt);
 
         /// Unselects the specified species as the presented badge if it is the currently equipped species.
         /// Used for resetting the equipped badge after a user lost all of that species' badges.


### PR DESCRIPTION
This is almost a direct port of the old core's behaviour. A few things are still blocking a merge:

- [X] Check linked accounts to not give out gift sub reward tokens for those (requires https://github.com/TwitchPlaysPokemon/tpp-core/pull/212)
- [X] Send overlay events (requires https://github.com/TwitchPlaysPokemon/tpp-core/pull/211)
- [X] ~Hook up emote service to parse emotes and include them in the overlay event~ just using the emotes twitch sends along for now
- [X] Better take another close look at the old core to see if I missed anything else
- [x] Disable sub handling in old core (https://github.com/TwitchPlaysPokemon/tpp/pull/487)
- [x] secondary websocket connection in old core (https://github.com/TwitchPlaysPokemon/tpp/pull/483)
