### PR TITLE
add websocket broadcast server to dualcore mode

### DIFF
--- a/TPP.Core/Modes/DualcoreMode.cs
+++ b/TPP.Core/Modes/DualcoreMode.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using TPP.Core.Commands.Definitions;
 using TPP.Core.Configuration;
+using TPP.Core.Overlay;
 
 namespace TPP.Core.Modes
 {
@@ -11,23 +12,30 @@ namespace TPP.Core.Modes
         private readonly ILogger<DualcoreMode> _logger;
         private readonly StopToken _stopToken;
         private readonly ModeBase _modeBase;
+        private readonly WebsocketBroadcastServer _broadcastServer;
+        private readonly OverlayConnection _overlayConnection;
 
         public DualcoreMode(ILoggerFactory loggerFactory, BaseConfig baseConfig)
         {
             _logger = loggerFactory.CreateLogger<DualcoreMode>();
             _stopToken = new StopToken();
             _modeBase = new ModeBase(loggerFactory, baseConfig, _stopToken);
+
+            (_broadcastServer, _overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
         }
 
         public async Task Run()
         {
             _logger.LogInformation("Dualcore mode starting");
             _modeBase.Start();
+            Task overlayWebsocketTask = _broadcastServer.Listen();
             while (!_stopToken.ShouldStop)
             {
                 // there is no sequence, just busyloop
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
             }
+            await _broadcastServer.Stop();
+            await overlayWebsocketTask;
             _logger.LogInformation("Dualcore mode ended");
         }
 

--- a/TPP.Core/Modes/Matchmode.cs
+++ b/TPP.Core/Modes/Matchmode.cs
@@ -31,10 +31,7 @@ namespace TPP.Core.Modes
             _stopToken = new StopToken();
             _modeBase = new ModeBase(loggerFactory, baseConfig, _stopToken);
 
-            _broadcastServer = new WebsocketBroadcastServer(
-                loggerFactory.CreateLogger<WebsocketBroadcastServer>(), "localhost", 5001);
-            _overlayConnection =
-                new OverlayConnection(loggerFactory.CreateLogger<OverlayConnection>(), _broadcastServer);
+            (_broadcastServer, _overlayConnection) = Setups.SetUpOverlayServer(loggerFactory);
         }
 
         public async Task Run()

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -10,6 +10,7 @@ using TPP.Core.Chat;
 using TPP.Core.Commands;
 using TPP.Core.Commands.Definitions;
 using TPP.Core.Configuration;
+using TPP.Core.Overlay;
 using TPP.Persistence.Models;
 using TPP.Persistence.MongoDB;
 using TPP.Persistence.MongoDB.Repos;
@@ -139,6 +140,16 @@ namespace TPP.Core
                 MessagequeueRepo: new MessagequeueRepo(mongoDatabase),
                 MessagelogRepo: new MessagelogRepo(mongoDatabaseMessagelog)
             );
+        }
+
+        public static (WebsocketBroadcastServer, OverlayConnection) SetUpOverlayServer(ILoggerFactory loggerFactory)
+        {
+            (string wsHost, int wsPort) = ("localhost", 5001);
+            WebsocketBroadcastServer broadcastServer = new(
+                loggerFactory.CreateLogger<WebsocketBroadcastServer>(), wsHost, wsPort);
+            OverlayConnection overlayConnection = new(
+                loggerFactory.CreateLogger<OverlayConnection>(), broadcastServer);
+            return (broadcastServer, overlayConnection);
         }
     }
 }


### PR DESCRIPTION
This is required for e.g. transmutation or subscription handling,
since those events have visual representations on the overlay