### PR TITLE
fix some log messages being dropped when aborting program

### DIFF
--- a/TPP.Core/InputServer.cs
+++ b/TPP.Core/InputServer.cs
@@ -54,14 +54,14 @@ namespace TPP.Core
                     }
                     catch (HttpListenerException)
                     {
-                        _logger.LogInformation("input server listener was stopped.");
+                        _logger.LogDebug("input server listener was stopped");
                         return;
                     }
                     catch (ObjectDisposedException)
                     {
                         // GetContextAsync doesn't take a cancellation token,
                         // and stopping the http server can cause it to trip over itself for some reason.
-                        _logger.LogError("Encountered ObjectDisposedException while accepting an incoming connection.");
+                        _logger.LogError("Encountered ObjectDisposedException while accepting an incoming connection");
                         return;
                     }
 

--- a/TPP.Core/Overlay/WebsocketBroadcastServer.cs
+++ b/TPP.Core/Overlay/WebsocketBroadcastServer.cs
@@ -168,7 +168,7 @@ namespace TPP.Core.Overlay
                 }
                 catch (HttpListenerException)
                 {
-                    _logger.LogInformation("Websocket listener was stopped");
+                    _logger.LogDebug("Websocket listener was stopped");
                     return;
                 }
                 catch (ObjectDisposedException)

--- a/TPP.Core/Program.cs
+++ b/TPP.Core/Program.cs
@@ -50,7 +50,7 @@ Options:
             IDictionary<string, ValueObject> args = new Docopt().Apply(Usage, argv, exit: true);
             string? mode = null;
             string modeConfigFilename = args["--mode-config"].ToString();
-            if (args["--mode"] != null && !args["--mode"].IsNullOrEmpty)
+            if (args["--mode"] is { IsNullOrEmpty: false })
             {
                 mode = args["--mode"].ToString();
                 if (!DefaultConfigs.ContainsKey(mode))

--- a/TPP.Core/Program.cs
+++ b/TPP.Core/Program.cs
@@ -113,7 +113,7 @@ Options:
         private static void Mode(string modeName, string baseConfigFilename, string modeConfigFilename)
         {
             BaseConfig baseConfig = ReadConfig<BaseConfig>(baseConfigFilename);
-            using ILoggerFactory loggerFactory = BuildLoggerFactory(baseConfig);
+            ILoggerFactory loggerFactory = BuildLoggerFactory(baseConfig);
             ILogger logger = loggerFactory.CreateLogger("main");
             IMode mode = modeName switch
             {
@@ -123,6 +123,7 @@ Options:
                 "dummy" => new DummyMode(loggerFactory, baseConfig),
                 _ => throw new NotSupportedException($"Invalid mode '{modeName}'")
             };
+            TaskCompletionSource<bool> cleanupDone = new();
             try
             {
                 Task modeTask = mode.Run();
@@ -130,7 +131,7 @@ Options:
                 {
                     logger.LogInformation("Aborting mode...");
                     mode.Cancel();
-                    modeTask.Wait();
+                    cleanupDone.Task.Wait();
                 }
                 AppDomain.CurrentDomain.ProcessExit += Abort; // SIGTERM
                 Console.CancelKeyPress += Abort; // CTRL-C / SIGINT
@@ -140,6 +141,8 @@ Options:
             {
                 logger.LogCritical(ex, "uncaught exception! TPP is crashing now, goodbye");
             }
+            loggerFactory.Dispose();
+            cleanupDone.SetResult(true);
         }
 
         private static void TestConfig(


### PR DESCRIPTION
the Abort handler for the ProcessExit and CancelKeyPress event was waiting for the mode to finish,
but failed to account for the fact that the process immediately terminates after that was done,
which in terms does not properly dispose stuff like the logger factory.
The latter is required for any remaining log messages to be flushed out.