### PR TITLE
add `venv*` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,3 +306,6 @@ config*.json
 
 # also ignore regular dotsettings files, as there currently is nothing it accomplishes.
 *.DotSettings
+
+# ignore python virtual environments
+venv*/


### PR DESCRIPTION
I set up a python virtual environment for the workflow python scripts, and those are naturally in the project root.