### PR TITLE
prepare for .NET 6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
         working-directory: TPP.Core
 
     steps:
-      - name: Setup .NET 5
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - uses: actions/checkout@v2
       - name: Publish the core
         run: dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true --no-self-contained -p:IncludeNativeLibrariesForSelfExtract=true
@@ -28,5 +28,5 @@ jobs:
         run: |
           echo "$SSHPRIVKEY" > tpp.key
           chmod 600 tpp.key
-          scp -q -i tpp.key -o StrictHostKeyChecking=no -P ${SSHPORT} bin/Release/net5.0/linux-x64/publish/TPP.Core ${SSHUSER}@${SSHHOST}:core_update
+          scp -q -i tpp.key -o StrictHostKeyChecking=no -P ${SSHPORT} bin/Release/net6.0/linux-x64/publish/TPP.Core ${SSHUSER}@${SSHHOST}:core_update
           cat ../.github/workflows/deploy.sh | ssh -q -i tpp.key -o StrictHostKeyChecking=no -p ${SSHPORT} ${SSHUSER}@${SSHHOST}

--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -35,4 +35,4 @@ jobs:
           fi
       - name: check code formatting
         run: |
-          dotnet format --check --report=_format_report.json || python .github/workflows/process_format_report.py
+          dotnet format --verify-no-changes --report=_format_report.json || python .github/workflows/process_format_report.py

--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup .NET 5
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - uses: actions/checkout@v2
       - name: install resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools

--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: install resharper
         run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
-      - name: install dotnet-format
-        run: dotnet tool install -g dotnet-format
       - name: build solution before analysis
         run: dotnet build
       - name: determine changed files

--- a/.github/workflows/json-schemas.yml
+++ b/.github/workflows/json-schemas.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup .NET 5
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - uses: actions/checkout@v2
       - name: Regenerate core config json schemas
         run: |

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup .NET 5
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - uses: actions/checkout@v2
       - name: Try publishing and running dummy mode
         run: |
           cd TPP.Core
           dotnet run -- gendefaultconfig --outfile=config.json
           dotnet publish -c Release
-          timeout --preserve-status -k1 3 dotnet ./bin/Release/net5.0/TPP.Core.dll start -m dummy || exit_code=$?
+          timeout --preserve-status -k1 3 dotnet ./bin/Release/net6.0/TPP.Core.dll start -m dummy || exit_code=$?
           if [ $exit_code -ne 143 ]; then
               echo "expected exit code 143, which means the program handled SIGTERM, but got $exit_code"
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         dotnet-sdk-version:
           - 5.0.300 # currently running on stream
-          - 5.0.x
+          - 6.0.x
 
     steps:
-      - name: Setup .NET 5
+      - name: Setup .NET 6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-sdk-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         dotnet-sdk-version:
-          - 5.0.300 # currently running on stream
+          - 6.0.201 # currently running on stream
           - 6.0.x
 
     steps:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ taken care of by the old python core.
 Porting features over is an ongoing process.
 
 ## requirements
-- .NET 5 SDK, you can get one from [dotnet.microsoft.com](https://dotnet.microsoft.com/download) (It has to be .NET 5 SDK, not a later version or it won't work, click "All .NET versions" to find the right version)
+- .NET 6 SDK (exactly, not 7 or up), you can get one from [dotnet.microsoft.com](https://dotnet.microsoft.com/download)
 - If you use or run any components with persistence, MongoDB.
   See [TPP.Persistence.MongoDB](TPP.Persistence.MongoDB) for details.
 

--- a/TPP.Core/README.md
+++ b/TPP.Core/README.md
@@ -75,5 +75,5 @@ If you want faster startup times or graceful SIGTERM handling,
 For example, making a release build and running the resulting `dll` with the dotnet runtime may look like this:
 ```
 dotnet publish -c Release
-dotnet ./bin/Release/net5.0/TPP.Core.dll --help
+dotnet ./bin/Release/net6.0/TPP.Core.dll --help
 ```

--- a/TPP.Core/TPP.Core.csproj
+++ b/TPP.Core/TPP.Core.csproj
@@ -8,8 +8,8 @@
         <PackageReference Include="docopt.net" Version="0.7.0" />
         <PackageReference Include="JsonNet.ContractResolvers" Version="2.0.0" />
         <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
         <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />

--- a/TPP.Match/TPP.Match.csproj
+++ b/TPP.Match/TPP.Match.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TPP.Model/TPP.Model.csproj
+++ b/TPP.Model/TPP.Model.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-    </PropertyGroup>
-
     <ItemGroup>
       <PackageReference Include="NodaTime" Version="3.0.9" />
     </ItemGroup>


### PR DESCRIPTION
This does not set the target framework to 6 yet, but already runs the workflows with .NET 6 and claims .NET 6 is required in the READMEs. It's a non-breaking preparation for switching over to .NET 6