### PR TITLE
add some more features for sided inputs

### DIFF
--- a/TPP.Core/Commands/Definitions/InputtingCommands.cs
+++ b/TPP.Core/Commands/Definitions/InputtingCommands.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using TPP.Persistence;
+
+namespace TPP.Core.Commands.Definitions;
+
+public class InputtingCommands : ICommandCollection
+{
+    public IEnumerable<Command> Commands => new[]
+    {
+        new Command("left", ctx => PickSide(ctx, "left")),
+        new Command("right", ctx => PickSide(ctx, "right")),
+    };
+
+    private readonly IInputSidePicksRepo _inputSidePicksRepo;
+
+    public InputtingCommands(IInputSidePicksRepo inputSidePicksRepo) => _inputSidePicksRepo = inputSidePicksRepo;
+
+    private async Task<CommandResult> PickSide(CommandContext context, string side)
+    {
+        await _inputSidePicksRepo.SetSide(context.Message.User.Id, side);
+        return new CommandResult { Response = $"Selected side '{side}'" };
+    }
+}

--- a/TPP.Core/Configuration/InputConfig.cs
+++ b/TPP.Core/Configuration/InputConfig.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace TPP.Core.Configuration
 {
     /// Contains all parameters that affect how inputs are performed.
@@ -19,5 +21,10 @@ namespace TPP.Core.Configuration
         public int MinInputFrames { get; init; } = 1;
         public int MaxInputFrames { get; init; } = 100;
         public int MaxBufferLength { get; init; } = 1000;
+
+        [Description("Whether players can choose an input side per-input using a side prefix, e.g. 'left:'. " +
+                     "Disabling this typically means you expect players to choose a side using e.g. !left or !right. " +
+                     "This has no effect for non-dual-sided input profiles.")]
+        public bool AllowDirectedInputs { get; init; } = true;
     }
 }

--- a/TPP.Core/InputServer.cs
+++ b/TPP.Core/InputServer.cs
@@ -15,15 +15,15 @@ namespace TPP.Core
         private readonly string _host;
         private readonly int _port;
         private readonly MuteInputsToken _muteInputsToken;
+        private readonly Func<IInputFeed> _inputFeedSupplier;
 
         private HttpListener? _httpListener;
-        public IInputFeed InputFeed;
 
         public InputServer(
             ILogger<InputServer> logger,
             string host, int port,
             MuteInputsToken muteInputsToken,
-            IInputFeed inputFeed)
+            Func<IInputFeed> inputFeedSupplier)
         {
             _logger = logger;
             if (host is "0.0.0.0" or "::")
@@ -39,7 +39,7 @@ namespace TPP.Core
             _host = host;
             _port = port;
             _muteInputsToken = muteInputsToken;
-            InputFeed = inputFeed;
+            _inputFeedSupplier = inputFeedSupplier;
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace TPP.Core
                         }
                         else
                         {
-                            InputMap? inputMap = await InputFeed.HandleRequest(requestUrl);
+                            InputMap? inputMap = await _inputFeedSupplier().HandleRequest(requestUrl);
                             responseText = inputMap == null ? null : JsonSerializer.Serialize(inputMap);
                         }
                     }

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -86,6 +86,7 @@ namespace TPP.Core
                 ).Commands,
                 new PollCommands(databases.PollRepo).Commands,
                 new ManagePollCommands(databases.PollRepo).Commands,
+                new InputtingCommands(databases.InputSidePicksRepo).Commands,
                 new BadgeCommands(databases.BadgeRepo, databases.UserRepo, messageSender, knownSpecies).Commands,
                 new OperatorCommands(
                     stopToken, muteInputsToken, databases.PokeyenBank, databases.TokensBank,
@@ -121,6 +122,7 @@ namespace TPP.Core
             IResponseCommandRepo ResponseCommandRepo,
             IRunCounterRepo RunCounterRepo,
             IInputLogRepo InputLogRepo,
+            IInputSidePicksRepo InputSidePicksRepo,
             KeyValueStore KeyValueStore
         );
 
@@ -174,6 +176,7 @@ namespace TPP.Core
                 ResponseCommandRepo: new ResponseCommandRepo(mongoDatabase),
                 RunCounterRepo: new RunCounterRepo(mongoDatabase),
                 InputLogRepo: new InputLogRepo(mongoDatabase),
+                InputSidePicksRepo: new InputSidePicksRepo(mongoDatabase),
                 KeyValueStore: new KeyValueStore(mongoDatabase)
             );
         }

--- a/TPP.Core/config.runmode.schema.json
+++ b/TPP.Core/config.runmode.schema.json
@@ -46,6 +46,10 @@
         },
         "MaxBufferLength": {
           "type": "integer"
+        },
+        "AllowDirectedInputs": {
+          "description": "Whether players can choose an input side per-input using a side prefix, e.g. 'left:'. Disabling this typically means you expect players to choose a side using e.g. !left or !right. This has no effect for non-dual-sided input profiles.",
+          "type": "boolean"
         }
       }
     }

--- a/TPP.Inputting/Inputs/SideInput.cs
+++ b/TPP.Inputting/Inputs/SideInput.cs
@@ -6,10 +6,14 @@ namespace TPP.Inputting.Inputs
 
     public class SideInput : Input
     {
-        public InputSide Side { get; }
+        /// Which side this input is for.
+        /// Is settable because if the side is not specified explicitly within the input,
+        /// choosing a side can be a non-trivial task beyond an input parser's capabilities.
+        /// It seems easiest to let some post-processing just set it in-place.
+        public InputSide? Side { get; set; }
         public bool Direct { get; }
 
-        public SideInput(InputSide side, bool direct) : base("Side", "side", side.GetSideString())
+        public SideInput(InputSide? side, bool direct) : base("Side", "side", side?.GetSideString() ?? "")
         {
             Side = side;
             Direct = direct;

--- a/TPP.Inputting/Parsing/SidedInputParser.cs
+++ b/TPP.Inputting/Parsing/SidedInputParser.cs
@@ -5,9 +5,13 @@ using TPP.Inputting.Inputs;
 
 namespace TPP.Inputting.Parsing
 {
+    /// <summary>
+    /// Parses inputs so that each input set includes a <see cref="SideInput"/> indicating which side it belongs to.
+    /// Note that the <see cref="SideInput"/>'s side may be null if it was not specified in the input.
+    /// In this case it may be desirable to assign a side in a later step, beyond the scope of the input parser.
+    /// </summary>
     public class SidedInputParser : IInputParser
     {
-        private static bool _sideFlipFlop;
         private static readonly Regex LeftRegex =
             new(@"^(?:l|left)[:.@#](?<input>.*)$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex RightRegex =
@@ -38,12 +42,7 @@ namespace TPP.Inputting.Parsing
 
             if (inputSequence == null) return null;
             bool direct = inputSide != null;
-            if (inputSide == null)
-            {
-                inputSide = _sideFlipFlop ? InputSide.Left : InputSide.Right;
-                _sideFlipFlop = !_sideFlipFlop;
-            }
-            var sideInput = new SideInput(inputSide.Value, direct);
+            var sideInput = new SideInput(inputSide, direct);
             return new InputSequence(inputSequence.InputSets
                 .Select(set => new InputSet(set.Inputs.Append(sideInput).ToImmutableList())).ToImmutableList());
         }

--- a/TPP.Inputting/Parsing/SidedInputParser.cs
+++ b/TPP.Inputting/Parsing/SidedInputParser.cs
@@ -15,6 +15,8 @@ namespace TPP.Inputting.Parsing
 
         private readonly IInputParser _delegateParser;
 
+        public bool AllowDirectedInputs { get; set; }
+
         public SidedInputParser(IInputParser delegateParser)
         {
             _delegateParser = delegateParser;
@@ -25,8 +27,8 @@ namespace TPP.Inputting.Parsing
             InputSide? inputSide;
             InputSequence? inputSequence;
 
-            Match matchLeft = LeftRegex.Match(text);
-            Match matchRight = RightRegex.Match(text);
+            Match matchLeft = AllowDirectedInputs ? LeftRegex.Match(text) : Match.Empty;
+            Match matchRight = AllowDirectedInputs ? RightRegex.Match(text) : Match.Empty;
             if (matchLeft.Success)
                 (inputSide, inputSequence) = (InputSide.Left, _delegateParser.Parse(matchLeft.Groups["input"].Value));
             else if (matchRight.Success)

--- a/TPP.Persistence.MongoDB/Repos/InputSidePicksRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/InputSidePicksRepo.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+
+namespace TPP.Persistence.MongoDB.Repos;
+
+internal class SidePick
+{
+    [BsonId]
+    public string? UserId { get; init; }
+    [BsonElement("side")]
+    public string? Side { get; init; }
+}
+
+public class InputSidePicksRepo : IInputSidePicksRepo
+{
+    private const string CollectionName = "inputsidepicks";
+    private readonly IMongoCollection<SidePick> _collection;
+
+    public InputSidePicksRepo(IMongoDatabase database)
+    {
+        database.CreateCollectionIfNotExists(CollectionName).Wait();
+        _collection = database.GetCollection<SidePick>(CollectionName);
+    }
+
+    public async Task SetSide(string userId, string? side) =>
+        await _collection.FindOneAndUpdateAsync(
+            Builders<SidePick>.Filter.Eq(pick => pick.UserId, userId),
+            Builders<SidePick>.Update.Set(pick => pick.Side, side),
+            new FindOneAndUpdateOptions<SidePick> { IsUpsert = true });
+
+    public async Task<string?> GetSide(string userId) =>
+        (await _collection.Find(pick => pick.UserId == userId).FirstOrDefaultAsync())?.Side;
+}

--- a/TPP.Persistence/IInputSidePicksRepo.cs
+++ b/TPP.Persistence/IInputSidePicksRepo.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace TPP.Persistence;
+
+public interface IInputSidePicksRepo
+{
+    public Task SetSide(string userId, string? side);
+    public Task<string?> GetSide(string userId);
+}


### PR DESCRIPTION
- [X] Allow `l`, `left`, `r`, `right` as side and `:`, `.` `@`, `#` as delimiter.
- [x] Allow choosing side with `!left` or `!right`, letting people omit the side prefix afterwards.
- [x] Add config to disallow directed inputs and force people to pick a side instead.
- [ ] Add configurable throttle for how often people can switch sides. Default is no throttle.
