### PR TITLE
Adds support for fakemon transmutation. 

### DIFF
--- a/TPP.Core/Commands/Definitions/TransmuteCommands.cs
+++ b/TPP.Core/Commands/Definitions/TransmuteCommands.cs
@@ -22,8 +22,9 @@ public class TransmuteCommands : ICommandCollection
     {
         new Command("transmute", Transmute)
         {
-            Description = "Transform 3 or more badges into a (usually) rarer badge. Costs one token. " +
-                          "Arguments: <several Pokemon>(at least 3) t1"
+            Description = "Transform 3 or more badges into a (usually) rarer badge. Costs one or ten token(s). T1 shall be provided" +
+                          " for regular transmutation, T10 will start a special transmutation that results in a fakemon badge. " +
+                          "Arguments: <several Pokemon>(at least 3) T1 / T10"
         },
     };
 
@@ -52,7 +53,7 @@ public class TransmuteCommands : ICommandCollection
         if (!tokensArg.IsPresent)
             return new CommandResult
             {
-                Response = $"Please include payment 'T{ITransmutationCalculator.TransmutationCost}' in your command"
+                Response = $"Please include payment 'T{ITransmutationCalculator.TransmutationCostStandard}' or 'T{ITransmutationCalculator.TransmutationCostSpecial}' in your command"
             };
         ImmutableList<PkmnSpecies> speciesList = speciesArg.Values;
 

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -73,15 +73,21 @@ namespace TPP.Core
             Databases databases,
             OverlayConnection overlayConnection)
         {
-            ImmutableSortedSet<PkmnSpecies> transmutableSpecies = knownSpecies
+            ImmutableSortedSet<PkmnSpecies> transmutableSpeciesStandard = knownSpecies
                 .Where(s => s.GetGeneration()
                     is Generation.Gen1 or Generation.Gen2 or Generation.Gen3 or Generation.Gen4
                     or Generation.Gen5 or Generation.Gen6 or Generation.Gen7 or Generation.Gen8
                 )
                 .ToImmutableSortedSet();
+            ImmutableSortedSet<PkmnSpecies> transmutableSpeciesSpecial = knownSpecies
+                .Where(s => s.GetGeneration()
+                    is Generation.GenFake
+                )
+                .ToImmutableSortedSet();
             ITransmutationCalculator transmutationCalculator = new TransmutationCalculator(
                 badgeStatsRepo: databases.BadgeStatsRepo,
-                transmutableSpecies: transmutableSpecies,
+                transmutableSpeciesStandard: transmutableSpeciesStandard,
+                transmutableSpeciesSpecial: transmutableSpeciesSpecial,
                 random: new Random().NextDouble);
             ITransmuter transmuter = new Transmuter(
                 databases.BadgeRepo, transmutationCalculator, databases.TokensBank, databases.TransmutationLogRepo,


### PR DESCRIPTION

Some notes:
* Fakemon transmutation (called Special transmutation in code) Costs T10. Regular (Standard) transmutation can still be triggered by adding T1 to the transmute command obviously
* Both special and standard transmutation use the same formula that was unchanged by this PR. 
* Special Transmutation requires one badge to have at least 11.0 Logarithmic inverse rarity.
*  This PR does not change the bug that fakemons can be transmuted atm. This will be fixed in a separate PR.

No Unit tests have been written (yet). Problem is that you can't really transmute anything with an (near) empty badge database as none of the badges will come even close to 11.0 in log inverse rarity. 

Things left to Discuss:
* Is T10 an acceptable price for special transmutations or should it be higher/lower?
* Should special transmutation use the same formula as standard transmutation?
* Is a static check for Log Inverse Rarity 11.0 a good thing? Right now this means that every badge with 48 or fewer existing (280 badge species) are eligible for fakemon transmutation which sounds like a lot, but in reality probably isn't because 2 more runs with full dexes (Randomized Shield, Radical Red, ...) will push a lot of badges out of this threshold.