### PR TITLE
Use Twitch API instead of chat for whispering

### DIFF
--- a/TPP.Core/Chat/TwitchApiRefresher.cs
+++ b/TPP.Core/Chat/TwitchApiRefresher.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using TwitchLib.Api;
+using TwitchLib.Api.Auth;
+using TwitchLib.Api.Core;
+
+namespace TPP.Core.Chat;
+
+/// <summary>
+/// Currently, access tokens don't seem to expire, but Twitch says they do: https://dev.twitch.tv/docs/authentication/refresh-tokens/
+/// Just to be sure we don't just die once they actually do expire, let's employ a quick and dirty refresh mechanism.
+/// </summary>
+public class TwitchApiProvider
+{
+    private static readonly Duration RefreshEarlier = Duration.FromSeconds(10);
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger<TwitchApiProvider> _logger;
+    private readonly IClock _clock;
+    private readonly string _refreshToken;
+    private readonly string _userClientId;
+    private readonly string _appClientId;
+    private readonly string _appClientSecret;
+    private readonly TwitchAPI _authlessApi;
+    private TwitchAPI? _api = null;
+    private Instant _apiValidUntil = Instant.MinValue;
+
+    public TwitchApiProvider(
+        ILoggerFactory loggerFactory,
+        IClock clock,
+        string refreshToken,
+        string userClientId,
+        string appClientId,
+        string appClientSecret)
+    {
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<TwitchApiProvider>();
+        _clock = clock;
+        _refreshToken = refreshToken;
+        _authlessApi = new TwitchAPI();
+        _userClientId = userClientId;
+        _appClientId = appClientId;
+        _appClientSecret = appClientSecret;
+    }
+
+    private async Task<TwitchAPI> GetInternal()
+    {
+        Instant now = _clock.GetCurrentInstant();
+        if (_api != null && _apiValidUntil >= now - RefreshEarlier)
+        {
+            return _api;
+        }
+        _logger.LogDebug("Twitch-API access_token expired or not initialized, refreshing API...");
+        RefreshResponse result = await _authlessApi.Auth.RefreshAuthTokenAsync(
+            refreshToken: _refreshToken,
+            clientSecret: _appClientSecret,
+            clientId: _appClientId
+        ) ?? throw new ArgumentNullException(null, "The refresh auth token result cannot be null");
+        _api = new TwitchAPI(_loggerFactory, settings: new ApiSettings
+        {
+            ClientId = _userClientId,
+            AccessToken = result.AccessToken
+        });
+        if (result.ExpiresIn <= 0)
+        {
+            _apiValidUntil = Instant.MaxValue;
+            _logger.LogDebug("Received non-expiring token, setting expiry date to {ExpiresAt}", _apiValidUntil);
+        }
+        else
+        {
+            _apiValidUntil = now.Plus(Duration.FromSeconds(result.ExpiresIn));
+            _logger.LogDebug("New access token expires in {ExpiresIn}s, at {ExpiresAt}", result.ExpiresIn,
+                _apiValidUntil);
+        }
+        return _api;
+    }
+
+    public async Task<TwitchAPI> Get()
+    {
+        await _semaphore.WaitAsync();
+        try
+        {
+            return await GetInternal();
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+}

--- a/TPP.Core/Chat/TwitchChat.cs
+++ b/TPP.Core/Chat/TwitchChat.cs
@@ -11,8 +11,6 @@ using TPP.Core.Overlay;
 using TPP.Core.Overlay.Events;
 using TPP.Model;
 using TPP.Persistence;
-using TwitchLib.Api;
-using TwitchLib.Api.Core;
 using TwitchLib.Client;
 using TwitchLib.Client.Events;
 using TwitchLib.Client.Extensions;
@@ -88,11 +86,13 @@ namespace TPP.Core.Chat
             _overlayConnection = overlayConnection;
             _useTwitchReplies = useTwitchReplies;
 
-            var twitchApi = new TwitchAPI(loggerFactory, settings: new ApiSettings
-            {
-                ClientId = chatConfig.ClientId,
-                AccessToken = chatConfig.AccessToken,
-            });
+            var twitchApiProvider = new TwitchApiProvider(
+                loggerFactory,
+                clock,
+                chatConfig.RefreshToken,
+                chatConfig.UserClientId,
+                chatConfig.AppClientId,
+                chatConfig.AppClientSecret);
             _twitchClient = new TwitchClient(
                 client: new WebSocketClient(new ClientOptions
                 {
@@ -125,7 +125,7 @@ namespace TPP.Core.Chat
             _queue = new TwitchChatQueue(
                 loggerFactory.CreateLogger<TwitchChatQueue>(),
                 chatConfig.UserId,
-                twitchApi,
+                twitchApiProvider,
                 _twitchClient);
         }
 

--- a/TPP.Core/Chat/TwitchChat.cs
+++ b/TPP.Core/Chat/TwitchChat.cs
@@ -89,8 +89,8 @@ namespace TPP.Core.Chat
             var twitchApiProvider = new TwitchApiProvider(
                 loggerFactory,
                 clock,
+                chatConfig.AccessToken,
                 chatConfig.RefreshToken,
-                chatConfig.UserClientId,
                 chatConfig.AppClientId,
                 chatConfig.AppClientSecret);
             _twitchClient = new TwitchClient(

--- a/TPP.Core/Chat/TwitchChat.cs
+++ b/TPP.Core/Chat/TwitchChat.cs
@@ -11,13 +11,15 @@ using TPP.Core.Overlay;
 using TPP.Core.Overlay.Events;
 using TPP.Model;
 using TPP.Persistence;
+using TwitchLib.Api;
+using TwitchLib.Api.Core;
 using TwitchLib.Client;
 using TwitchLib.Client.Events;
 using TwitchLib.Client.Extensions;
 using TwitchLib.Client.Models;
 using TwitchLib.Communication.Clients;
-using TwitchLib.Communication.Models;
 using TwitchLib.Communication.Events;
+using TwitchLib.Communication.Models;
 using static TPP.Core.Configuration.ConnectionConfig.Twitch;
 using static TPP.Core.EventUtils;
 
@@ -31,13 +33,21 @@ namespace TPP.Core.Chat
         /// Twitch Messaging Interface (TMI, the somewhat IRC-compatible protocol twitch uses) maximum message length.
         /// This limit is in characters, not bytes. See https://discuss.dev.twitch.tv/t/message-character-limit/7793/6
         private const int MaxMessageLength = 500;
+        /// Maximum message length for whispers if the target user hasn't whispered us before.
+        /// See also https://dev.twitch.tv/docs/api/reference/#send-whisper
+        private const int MaxWhisperLength = 500;
+        /// Maximum message length for whispers if the target user _has_ whispered us before.
+        /// See also https://dev.twitch.tv/docs/api/reference/#send-whisper
+        private const int MaxRepeatedWhisperLength = 10000;
 
         private static readonly MessageSplitter MessageSplitterRegular = new(
             maxMessageLength: MaxMessageLength - "/me ".Length);
 
-        private static readonly MessageSplitter MessageSplitterWhisper = new(
-            // visual representation of the longest possible username (25 characters)
-            maxMessageLength: MaxMessageLength - "/w ,,,,,''''',,,,,''''',,,,, ".Length);
+        private static readonly MessageSplitter MessageSplitterWhisperNeverWhispered = new(
+            maxMessageLength: MaxWhisperLength);
+
+        private static readonly MessageSplitter MessageSplitterWhisperWereWhisperedBefore = new(
+            maxMessageLength: MaxRepeatedWhisperLength);
 
         private readonly ILogger<TwitchChat> _logger;
         private readonly IClock _clock;
@@ -78,6 +88,11 @@ namespace TPP.Core.Chat
             _overlayConnection = overlayConnection;
             _useTwitchReplies = useTwitchReplies;
 
+            var twitchApi = new TwitchAPI(loggerFactory, settings: new ApiSettings
+            {
+                ClientId = chatConfig.ClientId,
+                AccessToken = chatConfig.AccessToken,
+            });
             _twitchClient = new TwitchClient(
                 client: new WebSocketClient(new ClientOptions
                 {
@@ -107,7 +122,11 @@ namespace TPP.Core.Chat
             _subscriptionWatcher.Subscribed += OnSubscribed;
             _subscriptionWatcher.SubscriptionGifted += OnSubscriptionGifted;
 
-            _queue = new TwitchChatQueue(loggerFactory.CreateLogger<TwitchChatQueue>(), _twitchClient);
+            _queue = new TwitchChatQueue(
+                loggerFactory.CreateLogger<TwitchChatQueue>(),
+                chatConfig.UserId,
+                twitchApi,
+                _twitchClient);
         }
 
         private void Connected(object? sender, OnConnectedArgs e) => _twitchClient.JoinChannel(_ircChannel);
@@ -250,11 +269,15 @@ namespace TPP.Core.Chat
                 return;
             }
             _logger.LogDebug(">@{Username}: {Message}", target.SimpleName, message);
+            bool newRecipient = target.LastWhisperReceivedAt == null;
+            MessageSplitter splitter = newRecipient
+                ? MessageSplitterWhisperNeverWhispered
+                : MessageSplitterWhisperWereWhisperedBefore;
             await Task.Run(() =>
             {
-                foreach (string part in MessageSplitterWhisper.FitToMaxLength(message))
+                foreach (string part in splitter.FitToMaxLength(message))
                 {
-                    _queue.Enqueue(target, new OutgoingMessage.Whisper(target.SimpleName, part));
+                    _queue.Enqueue(target, new OutgoingMessage.Whisper(target.Id, part, newRecipient));
                 }
             });
         }
@@ -317,7 +340,7 @@ namespace TPP.Core.Chat
                 if (e.ChatMessage.Username == _twitchClient.TwitchUsername)
                     // new core sees messages posted by old core, but we don't want to process our own messages
                     return;
-                User user = await _userRepo.RecordUser(GetUserInfoFromTwitchMessage(e.ChatMessage));
+                User user = await _userRepo.RecordUser(GetUserInfoFromTwitchMessage(e.ChatMessage, fromWhisper: false));
                 var message = new Message(user, e.ChatMessage.Message, MessageSource.Chat, e.ChatMessage.RawIrcMessage)
                 {
                     Details = new MessageDetails(
@@ -337,7 +360,8 @@ namespace TPP.Core.Chat
             TaskToVoidSafely(_logger, async () =>
             {
                 _logger.LogDebug("<@{Username}: {Message}", e.WhisperMessage.Username, e.WhisperMessage.Message);
-                User user = await _userRepo.RecordUser(GetUserInfoFromTwitchMessage(e.WhisperMessage));
+                User user = await _userRepo.RecordUser(
+                    GetUserInfoFromTwitchMessage(e.WhisperMessage, fromWhisper: true));
                 var message = new Message(user, e.WhisperMessage.Message, MessageSource.Whisper,
                     e.WhisperMessage.RawIrcMessage)
                 {
@@ -353,7 +377,7 @@ namespace TPP.Core.Chat
             });
         }
 
-        private UserInfo GetUserInfoFromTwitchMessage(TwitchLibMessage message)
+        private UserInfo GetUserInfoFromTwitchMessage(TwitchLibMessage message, bool fromWhisper)
         {
             string? colorHex = message.ColorHex;
             return new UserInfo(
@@ -362,6 +386,7 @@ namespace TPP.Core.Chat
                 SimpleName: message.Username,
                 Color: string.IsNullOrEmpty(colorHex) ? null : HexColor.FromWithHash(colorHex),
                 FromMessage: true,
+                FromWhisper: fromWhisper,
                 UpdatedAt: _clock.GetCurrentInstant()
             );
         }

--- a/TPP.Core/Configuration/ConnectionConfig.cs
+++ b/TPP.Core/Configuration/ConnectionConfig.cs
@@ -35,9 +35,11 @@ namespace TPP.Core.Configuration
             public string UserId { get; init; } = "1234567";
             public string Username { get; init; } = "justinfan27365461784";
             public string Password { get; init; } = "oauth:mysecret";
-            public string ClientId { get; init; } = "myclientid";
-            public string AccessToken { get; init; } = "myaccesstoken";
-            // public string RefreshToken { get; init; } = "asdadasd";
+            public string UserClientId { get; init; } = "myuserclientid";
+            // the access token gets created dynamically from the refresh token
+            public string RefreshToken { get; init; } = "myrefreshtoken";
+            public string AppClientId { get; init; } = "myappclientid";
+            public string AppClientSecret { get; init; } = "myappclientsecret";
 
             /* communication settings */
             public enum SuppressionType { Whisper, Message, Command }

--- a/TPP.Core/Configuration/ConnectionConfig.cs
+++ b/TPP.Core/Configuration/ConnectionConfig.cs
@@ -32,8 +32,12 @@ namespace TPP.Core.Configuration
             public string Channel { get; init; } = "twitchplayspokemon";
 
             /* account information */
+            public string UserId { get; init; } = "1234567";
             public string Username { get; init; } = "justinfan27365461784";
             public string Password { get; init; } = "oauth:mysecret";
+            public string ClientId { get; init; } = "myclientid";
+            public string AccessToken { get; init; } = "myaccesstoken";
+            // public string RefreshToken { get; init; } = "asdadasd";
 
             /* communication settings */
             public enum SuppressionType { Whisper, Message, Command }

--- a/TPP.Core/Configuration/ConnectionConfig.cs
+++ b/TPP.Core/Configuration/ConnectionConfig.cs
@@ -35,9 +35,10 @@ namespace TPP.Core.Configuration
             public string UserId { get; init; } = "1234567";
             public string Username { get; init; } = "justinfan27365461784";
             public string Password { get; init; } = "oauth:mysecret";
-            public string UserClientId { get; init; } = "myuserclientid";
-            // the access token gets created dynamically from the refresh token
-            public string RefreshToken { get; init; } = "myrefreshtoken";
+            // if an access token is specified, assumes it has infinite validity and always uses that one
+            public string? AccessToken { get; init; } = "myaccesstoken";
+            // if no access token is specified, dynamically create access tokens from this refresh token
+            public string? RefreshToken { get; init; } = "myrefreshtoken";
             public string AppClientId { get; init; } = "myappclientid";
             public string AppClientSecret { get; init; } = "myappclientsecret";
 

--- a/TPP.Core/Program.cs
+++ b/TPP.Core/Program.cs
@@ -127,6 +127,9 @@ Options:
                         .MinimumLevel.Is(baseConfig.DiscordLoggingConfig.MinLogLevel)
                         .CreateLogger());
                 }
+                // TwitchLib.API ist quite spammy, but more importantly, it prints all HTTP calls at info level.
+                // That is bad, because it may include auth calls, which include secrets in their query params.
+                builder.AddFilter("TwitchLib.Api", level => level >= LogLevel.Warning);
             });
 
         private static void Mode(string modeName, string baseConfigFilename, string modeConfigFilename)

--- a/TPP.Core/TPP.Core.csproj
+++ b/TPP.Core/TPP.Core.csproj
@@ -15,8 +15,9 @@
         <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
         <PackageReference Include="Serilog.Sinks.Discord" Version="1.2.1" />
         <PackageReference Include="String.Similarity" Version="3.0.0" />
+        <PackageReference Include="TwitchLib.Api" Version="3.9.0-preview-f7f2908" />
         <!-- Earliest version to include this fix: https://github.com/TwitchLib/TwitchLib.Client/pull/170 -->
-        <PackageReference Include="TwitchLib.Client" Version="3.3.1" />
+        <PackageReference Include="TwitchLib.Client" Version="3.4.0-preview-d6687358268723051c755034b155a703c97c353a" />
     </ItemGroup>
 
     <ItemGroup>

--- a/TPP.Model/User.cs
+++ b/TPP.Model/User.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NodaTime;
 using TPP.Common;
+
 //public record Match(long Pokeyen, long Tokens, long PokeyenHighScore);
 
 namespace TPP.Model;
@@ -37,6 +38,7 @@ public class User : PropertyEquatable<User>
     // public Instant? FollowedAt { get; init; }
     // public Instant? LastBetAt { get; init; }
     public Instant? LastMessageAt { get; init; }
+    public Instant? LastWhisperReceivedAt { get; init; }
 
     public long Pokeyen { get; init; }
     public long Tokens { get; init; }
@@ -87,6 +89,7 @@ public class User : PropertyEquatable<User>
         long pokeyen,
         long tokens,
         long pokeyenHighScore = 0,
+        Instant? lastWhisperReceivedAt = null,
         SortedSet<int>? participationEmblems = null,
         int? selectedParticipationEmblem = null,
         PkmnSpecies? selectedBadge = null,
@@ -108,6 +111,7 @@ public class User : PropertyEquatable<User>
         FirstActiveAt = firstActiveAt;
         LastActiveAt = lastActiveAt;
         LastMessageAt = lastMessageAt;
+        LastWhisperReceivedAt = lastWhisperReceivedAt;
         Pokeyen = pokeyen;
         Tokens = tokens;
         PokeyenHighScore = pokeyenHighScore;

--- a/TPP.Persistence.MongoDB/Repos/UserRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/UserRepo.cs
@@ -34,6 +34,7 @@ namespace TPP.Persistence.MongoDB.Repos
                 cm.MapProperty(u => u.FirstActiveAt).SetElementName("first_active_at");
                 cm.MapProperty(u => u.LastActiveAt).SetElementName("last_active_at");
                 cm.MapProperty(u => u.LastMessageAt).SetElementName("last_message_at");
+                cm.MapProperty(u => u.LastWhisperReceivedAt).SetElementName("last_whisper_received_at");
                 cm.MapProperty(u => u.Pokeyen).SetElementName("pokeyen");
                 cm.MapProperty(u => u.PokeyenHighScore).SetElementName("pokeyen_highscore")
                     .SetDefaultValue(0L)
@@ -119,6 +120,10 @@ namespace TPP.Persistence.MongoDB.Repos
             if (userInfo.FromMessage)
             {
                 update = update.Set(u => u.LastMessageAt, updatedAt);
+            }
+            if (userInfo.FromWhisper)
+            {
+                update = update.Set(u => u.LastWhisperReceivedAt, updatedAt);
             }
 
             async Task<User?> UpdateExistingUser() => await Collection.FindOneAndUpdateAsync<User>(

--- a/TPP.Persistence/UserInfo.cs
+++ b/TPP.Persistence/UserInfo.cs
@@ -10,5 +10,6 @@ public readonly record struct UserInfo
     string SimpleName,
     HexColor? Color = null,
     bool FromMessage = false,
+    bool FromWhisper = false,
     Instant? UpdatedAt = null
 );


### PR DESCRIPTION
Twitch removed some chat commands, including `/w` for whispering. Here's the migration guide: https://dev.twitch.tv/docs/irc/chat-commands/#migration-guide

This PR fixes sending whispers. It uses a prerelease version of the TwitchLib.API package, as suggested here: https://github.com/TwitchLib/TwitchLib/issues/1115#issuecomment-1445465374

This change requires additional stuff to be configured, namely the userid (for `tpp` that will be `57604599`), the Client-Secret and Client-ID of our TPP Twitch app (I already configured them), and an access token and refresh token generated using that twitch app. For whispering the token needs the `user:manage:whispers` scope. You can use [twitchplayspokemon.tv/custom_scopes](https://twitchplayspokemon.tv/custom_scopes) to generate those.

Also the account whispering (`tpp`) needs to have a verified phone number linked.