### PR TITLE
migrate more now defunct chat commands to API

### DIFF
--- a/TPP.Core/Configuration/ConnectionConfig.cs
+++ b/TPP.Core/Configuration/ConnectionConfig.cs
@@ -30,6 +30,7 @@ namespace TPP.Core.Configuration
 
             /* connection information */
             public string Channel { get; init; } = "twitchplayspokemon";
+            public string ChannelId { get; init; } = "56648155";
 
             /* account information */
             public string UserId { get; init; } = "1234567";

--- a/TPP.Core/TPP.Core.csproj
+++ b/TPP.Core/TPP.Core.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="String.Similarity" Version="3.0.0" />
         <PackageReference Include="TwitchLib.Api" Version="3.9.0-preview-f7f2908" />
         <!-- Earliest version to include this fix: https://github.com/TwitchLib/TwitchLib.Client/pull/170 -->
-        <PackageReference Include="TwitchLib.Client" Version="3.4.0-preview-d6687358268723051c755034b155a703c97c353a" />
+        <PackageReference Include="TwitchLib.Client" Version="3.4.0-preview-01edbf25dc9a228a3022fe6fefc018841df8368b" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
migrated !timeout, !ban, !unban, !emoteonly and !emoteonlyoff. Requires the access/refresh token pair to additionally have these scopes: `moderator:manage:banned_users` `moderator:manage:chat_settings` in addition to `user:manage:whispers` which is should already have