### PR TITLE
avoid self message

### DIFF
--- a/TPP.Core/Chat/TwitchChatQueue.cs
+++ b/TPP.Core/Chat/TwitchChatQueue.cs
@@ -71,7 +71,7 @@ namespace TPP.Core.Chat
             while (_queue.Count > _maxQueueLength)
             {
                 (string, OutgoingMessage) discarded = _queue.DequeueLast()!.Value;
-                _logger.LogDebug(
+                _logger.LogWarning(
                     "Outgoing message queue is full (size {Capacity})! Discarded message from user {User}: {Message}",
                     _maxQueueLength, discarded.Item1, discarded.Item2);
             }


### PR DESCRIPTION
Currently we sometimes get these messages errors:

```json
{"error":"Bad Request","status":400,"message":"A user cannot whisper themself"}
```

The bot got a gift and tried to whisper this to itself:

> xyz gave you a Gift Crate, and the content was 1 Badge Rain (owned badges of your choice rain down on stream)!

