### PR TITLE
Moderation: Support appeal cooldowns

### DIFF
--- a/TPP.Core/Commands/Definitions/ModerationCommands.cs
+++ b/TPP.Core/Commands/Definitions/ModerationCommands.cs
@@ -19,15 +19,17 @@ public class ModerationCommands : ICommandCollection
     private readonly IBanLogRepo _banLogRepo;
     private readonly ITimeoutLogRepo _timeoutLogRepo;
     private readonly IUserRepo _userRepo;
+    private readonly IAppealCooldownLogRepo _appealCooldownRepo;
     private readonly IClock _clock;
 
     public ModerationCommands(
-        ModerationService moderationService, IBanLogRepo banLogRepo, ITimeoutLogRepo timeoutLogRepo, IUserRepo userRepo,
+        ModerationService moderationService, IBanLogRepo banLogRepo, ITimeoutLogRepo timeoutLogRepo, IAppealCooldownLogRepo appealCooldownRepo, IUserRepo userRepo,
         IClock clock)
     {
         _moderationService = moderationService;
         _banLogRepo = banLogRepo;
         _timeoutLogRepo = timeoutLogRepo;
+        _appealCooldownRepo = appealCooldownRepo;
         _userRepo = userRepo;
         _clock = clock;
     }
@@ -40,6 +42,9 @@ public class ModerationCommands : ICommandCollection
         new Command("timeout", TimeoutCmd),
         new Command("untimeout", UntimeoutCmd),
         new Command("checktimeout", CheckTimeout),
+        new Command("setappealcooldown", SetAppealCooldown),
+        new Command("setunappealable", SetUnappealable),
+        new Command("checkappealcooldown", CheckAppealCooldown),
     }.Select(cmd => cmd.WithModeratorsOnly());
 
     private static string ParseReasonArgs(ManyOf<string> reasonParts)
@@ -160,6 +165,61 @@ public class ModerationCommands : ICommandCollection
             Response = remainingTimeout > Duration.Zero
                 ? $"{targetUser.Name} is timed out for another {remainingTimeout.ToTimeSpan().ToHumanReadable()}. {infoText}"
                 : $"{targetUser.Name} is not timed out. {infoText}"
+        };
+    }
+
+    private async Task<CommandResult> SetAppealCooldown(CommandContext context)
+    {
+        (User targetUser, TimeSpan timeSpan) =
+             await context.ParseArgs<User, TimeSpan>();
+        Duration duration = Duration.FromTimeSpan(timeSpan);
+        return new CommandResult
+        {
+            Response = await _moderationService.SetAppealCooldown(context.Message.User, targetUser, duration) switch
+            {
+                SetAppealCooldownResult.Ok => $"{targetUser.Name} is now eligible to appeal at {_clock.GetCurrentInstant() + duration}.",
+                SetAppealCooldownResult.UserNotBanned => $"{targetUser.Name} is not banned.",
+                SetAppealCooldownResult.AlreadyPermanent => throw new InvalidOperationException("Unexpected AlreadyPermanent repsonse"),
+            }
+        };
+    }
+
+    private async Task<CommandResult> SetUnappealable(CommandContext context)
+    {
+        User targetUser = await context.ParseArgs<User>();
+        return new CommandResult
+        {
+            Response = await _moderationService.SetUnappealable(context.Message.User, targetUser) switch
+            {
+                SetAppealCooldownResult.Ok => $"{targetUser.Name} is now ineligible to appeal their ban.",
+                SetAppealCooldownResult.UserNotBanned => $"{targetUser.Name} is not banned.",
+                SetAppealCooldownResult.AlreadyPermanent => $"{targetUser.Name} is already ineligible to appeal.",
+            }
+        };
+    }
+
+    private async Task<CommandResult> CheckAppealCooldown(CommandContext context)
+    {
+        User targetUser = await context.ParseArgs<User>();
+        if (!targetUser.Banned)
+            return new CommandResult { Response = $"{targetUser.Name} is not banned." };
+
+        AppealCooldownLog? recentLog = await _appealCooldownRepo.FindMostRecent(targetUser.Id);
+        string? issuerName = recentLog?.IssuerUserId == null
+            ? "<automated>"
+            : (await _userRepo.FindById(recentLog.IssuerUserId))?.Name;
+        string infoText = recentLog == null
+            ? "No logs available."
+            : $"Last action was {recentLog.Type} by {issuerName} " +
+              $"at {recentLog.Timestamp}";
+        if (recentLog?.Duration != null) infoText += $" for {recentLog.Duration.Value.ToTimeSpan().ToHumanReadable()}";
+
+        return new CommandResult { Response =
+            targetUser.PermaBanned
+            ? $"{targetUser.Name} is not eligible to appeal. {infoText}"
+            : targetUser.AppealDate < _clock.GetCurrentInstant()
+            ? $"{targetUser.Name} is eligible to appeal now. {infoText}"
+            : $"{targetUser.Name} will be eligible to appeal on {targetUser.AppealDate}. {infoText}"
         };
     }
 }

--- a/TPP.Core/Moderation/ModerationService.cs
+++ b/TPP.Core/Moderation/ModerationService.cs
@@ -8,6 +8,7 @@ namespace TPP.Core.Moderation;
 
 public enum TimeoutResult { Ok, MustBe2WeeksOrLess, UserIsBanned, UserIsModOrOp, NotSupportedInChannel }
 public enum BanResult { Ok, UserIsModOrOp, NotSupportedInChannel }
+public enum SetAppealCooldownResult { Ok, UserNotBanned, AlreadyPermanent }
 public enum ModerationActionType { Ban, Unban, Timeout, Untimeout }
 public class ModerationActionPerformedEventArgs : EventArgs
 {
@@ -28,17 +29,19 @@ public class ModerationService
     private readonly IExecutor? _executor;
     private readonly ITimeoutLogRepo _timeoutLogRepo;
     private readonly IBanLogRepo _banLogRepo;
+    private readonly IAppealCooldownLogRepo _appealCooldownLogRepo;
     private readonly IUserRepo _userRepo;
 
     public event EventHandler<ModerationActionPerformedEventArgs>? ModerationActionPerformed;
 
     public ModerationService(
-        IClock clock, IExecutor? executor, ITimeoutLogRepo timeoutLogRepo, IBanLogRepo banLogRepo, IUserRepo userRepo)
+        IClock clock, IExecutor? executor, ITimeoutLogRepo timeoutLogRepo, IBanLogRepo banLogRepo, IAppealCooldownLogRepo appealCooldownLogRepo, IUserRepo userRepo)
     {
         _clock = clock;
         _executor = executor;
         _timeoutLogRepo = timeoutLogRepo;
         _banLogRepo = banLogRepo;
+        _appealCooldownLogRepo = appealCooldownLogRepo;
         _userRepo = userRepo;
     }
 
@@ -69,6 +72,14 @@ public class ModerationService
             targetUser.Id, isBan ? "untimeout_from_manual_ban" : "untimeout_from_manual_unban", reason,
             issuerUser.Id, now, null);
         await _userRepo.SetBanned(targetUser, isBan);
+
+        // First ban can be appealed after 1 month by default.
+        // I don't want to automatically calculate how many bans the user has had, because some might be joke/mistakes
+        // A mod should manually set the next appeal cooldown based on the rules.
+        var DEFAULT_APPEAL_TIME = Duration.FromDays(30);
+        Instant expiration = now + DEFAULT_APPEAL_TIME;
+        await _userRepo.SetAppealCooldown(targetUser, expiration);
+        await _appealCooldownLogRepo.LogAppealCooldownChange(targetUser.Id, "auto_appeal_cooldown", issuerUser.Id, now, DEFAULT_APPEAL_TIME);
 
         ModerationActionPerformed?.Invoke(this, new ModerationActionPerformedEventArgs(
             issuerUser, targetUser, isBan ? ModerationActionType.Ban : ModerationActionType.Unban));
@@ -111,5 +122,35 @@ public class ModerationService
             issuerUser, targetUser, isIssuing ? ModerationActionType.Timeout : ModerationActionType.Untimeout));
 
         return TimeoutResult.Ok;
+    }
+
+    public Task<SetAppealCooldownResult> SetAppealCooldown(User issueruser, User targetuser, Duration duration) =>
+        _SetAppealCooldown(issueruser, targetuser, duration);
+    public Task<SetAppealCooldownResult> SetUnappealable(User issueruser, User targetuser) =>
+        _SetAppealCooldown(issueruser, targetuser, null);
+
+    private async Task<SetAppealCooldownResult> _SetAppealCooldown(
+        User issueruser, User targetUser, Duration? duration)
+    {
+        if (!targetUser.Banned)
+            return SetAppealCooldownResult.UserNotBanned;
+
+        Instant now = _clock.GetCurrentInstant();
+
+        if (duration.HasValue)
+        {
+            Instant expiration = now + duration.Value;
+            await _userRepo.SetAppealCooldown(targetUser, expiration);
+            await _appealCooldownLogRepo.LogAppealCooldownChange(targetUser.Id, "manual_cooldown_change", issueruser.Id, now, duration);
+        }
+        else
+        {
+            if (targetUser.PermaBanned)
+                return SetAppealCooldownResult.AlreadyPermanent;
+            await _userRepo.SetAppealCooldown(targetUser, null);
+            await _appealCooldownLogRepo.LogAppealCooldownChange(targetUser.Id, "manual_perma", issueruser.Id, now, null);
+        }
+
+        return SetAppealCooldownResult.Ok;
     }
 }

--- a/TPP.Core/Setups.cs
+++ b/TPP.Core/Setups.cs
@@ -112,7 +112,8 @@ namespace TPP.Core
                 databases.CommandLogger, argsParser);
 
             var moderationService = new ModerationService(
-                SystemClock.Instance, executor, databases.TimeoutLogRepo, databases.BanLogRepo, databases.UserRepo);
+                SystemClock.Instance, executor, databases.TimeoutLogRepo, databases.BanLogRepo,
+                databases.AppealCooldownLogRepo, databases.UserRepo);
             ILogger<ModerationService> logger = loggerFactory.CreateLogger<ModerationService>();
             moderationService.ModerationActionPerformed += (_, args) => TaskToVoidSafely(logger, () =>
             {
@@ -139,7 +140,7 @@ namespace TPP.Core
                     chatModeChanger, databases.LinkedAccountRepo, databases.ResponseCommandRepo
                 ).Commands,
                 new ModerationCommands(
-                    moderationService, databases.BanLogRepo, databases.TimeoutLogRepo, databases.UserRepo,
+                    moderationService, databases.BanLogRepo, databases.TimeoutLogRepo, databases.AppealCooldownLogRepo, databases.UserRepo,
                     SystemClock.Instance
                 ).Commands
             }.SelectMany(cmds => cmds).ToList();
@@ -189,6 +190,7 @@ namespace TPP.Core
             IModbotLogRepo ModbotLogRepo,
             IBanLogRepo BanLogRepo,
             ITimeoutLogRepo TimeoutLogRepo,
+            IAppealCooldownLogRepo AppealCooldownLogRepo,
             IResponseCommandRepo ResponseCommandRepo,
             IRunCounterRepo RunCounterRepo,
             IInputLogRepo InputLogRepo,
@@ -252,6 +254,7 @@ namespace TPP.Core
                 ModbotLogRepo: new ModbotLogRepo(mongoDatabase),
                 BanLogRepo: new BanLogRepo(mongoDatabase),
                 TimeoutLogRepo: new TimeoutLogRepo(mongoDatabase),
+                AppealCooldownLogRepo: new AppealCooldownLogRepo(mongoDatabase),
                 ResponseCommandRepo: new ResponseCommandRepo(mongoDatabase),
                 RunCounterRepo: new RunCounterRepo(mongoDatabase),
                 InputLogRepo: new InputLogRepo(mongoDatabase),

--- a/TPP.Model/Logs.cs
+++ b/TPP.Model/Logs.cs
@@ -70,6 +70,8 @@ namespace TPP.Model
     public record TimeoutLog(
         string Id, string Type, string UserId, string Reason, string? IssuerUserId, Instant Timestamp,
         Duration? Duration);
+    public record AppealCooldownLog(
+        string Id, string Type, string UserId, string IssuerUserId, Instant Timestamp, Duration? Duration);
 
     public record SubscriptionLog(
         string Id,

--- a/TPP.Model/User.cs
+++ b/TPP.Model/User.cs
@@ -76,6 +76,15 @@ public class User : PropertyEquatable<User>
 
     public Instant? TimeoutExpiration { get; init; }
     public bool Banned { get; init; }
+    /// <summary>
+    /// Not to be confused with Banned. If true, this user can never submit an appeal.
+    /// </summary>
+    public bool PermaBanned { get; init; }
+    /// <summary>
+    /// When a user can appeal. For backwards compatibility, if this field is null,
+    /// it is assumed the user is allowed to appeal immediately unless PermaBanned is true.
+    /// </summary>
+    public Instant? AppealDate { get; init; }
 
     public User(
         string id,

--- a/TPP.Persistence.MongoDB/Repos/UserRepo.cs
+++ b/TPP.Persistence.MongoDB/Repos/UserRepo.cs
@@ -62,6 +62,8 @@ namespace TPP.Persistence.MongoDB.Repos
                 cm.MapProperty(u => u.TimeoutExpiration).SetElementName("timeout_expiration");
                 cm.MapProperty(u => u.Roles).SetElementName("roles")
                     .SetDefaultValue(new HashSet<Role>());
+                cm.MapProperty(u => u.PermaBanned).SetElementName("permabanned");
+                cm.MapProperty(u => u.AppealDate).SetElementName("appeal_date");
             });
         }
 
@@ -273,6 +275,14 @@ namespace TPP.Persistence.MongoDB.Repos
                 Builders<User>.Update
                     .Set(u => u.Banned, false)
                     .Set(u => u.TimeoutExpiration, timeoutExpiration),
+                new FindOneAndUpdateOptions<User> { ReturnDocument = ReturnDocument.After });
+
+        public async Task<User> SetAppealCooldown(User user, Instant? canAppeal) =>
+            await Collection.FindOneAndUpdateAsync<User>(
+                u => u.Id == user.Id,
+                Builders<User>.Update
+                    .Set(u => u.AppealDate, canAppeal)
+                    .Set(u => u.PermaBanned, !canAppeal.HasValue),
                 new FindOneAndUpdateOptions<User> { ReturnDocument = ReturnDocument.After });
     }
 }

--- a/TPP.Persistence/IUserRepo.cs
+++ b/TPP.Persistence/IUserRepo.cs
@@ -28,6 +28,10 @@ namespace TPP.Persistence
 
         public Task<User> SetBanned(User user, bool banned);
         public Task<User> SetTimedOut(User user, Instant? timeoutExpiration);
+        /// <summary>
+        ///  Sets the time a user can appeal a ban. Null = can't appeal.
+        /// </summary>
+        public Task<User> SetAppealCooldown(User user, Instant? canAppeal);
 
         /// Unselects the specified species as the presented badge if it is the currently equipped species.
         /// Used for resetting the equipped badge after a user lost all of that species' badges.

--- a/TPP.Persistence/ModerationRelatedRepos.cs
+++ b/TPP.Persistence/ModerationRelatedRepos.cs
@@ -20,4 +20,10 @@ namespace TPP.Persistence
             string userId, string type, string reason, string? issuerUserId, Instant timestamp, Duration? duration);
         Task<TimeoutLog?> FindMostRecent(string userId);
     }
+    public interface IAppealCooldownLogRepo
+    {
+        Task<AppealCooldownLog> LogAppealCooldownChange(
+            string userId, string type, string issuerUserId, Instant timestamp, Duration? duration);
+        Task<AppealCooldownLog?> FindMostRecent(string userId);
+    }
 }


### PR DESCRIPTION
* Adds 2 new fields to users: a date that they are allowed to appeal their ban, and a boolean for whether or not their ban is unappealable
* Adds 3 commands for moderators
  * setappealcooldown - sets the time a user must wait before appealing a ban
  * setunappealable - marks a user's ban as unappealable
  * checkappealcooldown - shows if and when a user is allowed to appeal
* Adds a new modlog repo for appeal cooldowns

Opening for preliminary reviews as I work on the web side of this