### PR TITLE
EventSub and overlay events for channel point redemptions

### DIFF
--- a/TPP.Core/Overlay/Events/ChannelPointRewardRedemption.cs
+++ b/TPP.Core/Overlay/Events/ChannelPointRewardRedemption.cs
@@ -1,0 +1,49 @@
+using System.Runtime.Serialization;
+using NodaTime;
+using TPP.Model;
+
+namespace TPP.Core.Overlay.Events;
+
+[DataContract]
+public enum RedemptionStatus
+{
+    [EnumMember(Value = "unknown")] Unknown,
+    [EnumMember(Value = "unfulfilled")] Unfulfilled,
+    [EnumMember(Value = "fulfilled")] Fulfilled,
+    [EnumMember(Value = "canceled")] Canceled
+}
+
+[DataContract]
+public struct RedemptionReward
+{
+    [DataMember(Name = "id")] public string Id { get; init; }
+    [DataMember(Name = "title")] public string Title { get; init; }
+    [DataMember(Name = "cost")] public int Cost { get; init; }
+    [DataMember(Name = "promp")] public string Prompt { get; init; }
+}
+
+[DataContract]
+public struct ChannelPointRewardRedemptionAdd : IOverlayEvent
+{
+    public string OverlayEventType => "channel_point_reward_redemption_add";
+
+    [DataMember(Name = "id")] public string Id { get; init; }
+    [DataMember(Name = "user")] public User User { get; init; }
+    [DataMember(Name = "user_input")] public string UserInput { get; init; }
+    [DataMember(Name = "status")] public RedemptionStatus Status { get; init; }
+    [DataMember(Name = "reward")] public RedemptionReward Reward { get; init; }
+    [DataMember(Name = "redeemed_at")] public Instant RedeemedAt { get; init; }
+}
+
+[DataContract]
+public struct ChannelPointRewardRedemptionUpdate : IOverlayEvent
+{
+    public string OverlayEventType => "channel_point_reward_redemption_update";
+
+    [DataMember(Name = "id")] public string Id { get; init; }
+    [DataMember(Name = "user")] public User User { get; init; }
+    [DataMember(Name = "user_input")] public string UserInput { get; init; }
+    [DataMember(Name = "status")] public RedemptionStatus Status { get; init; }
+    [DataMember(Name = "reward")] public RedemptionReward Reward { get; init; }
+    [DataMember(Name = "redeemed_at")] public Instant RedeemedAt { get; init; }
+}

--- a/TPP.Core/README.md
+++ b/TPP.Core/README.md
@@ -73,20 +73,21 @@ dotnet run -- start -m dualcore
 
 The following scopes are currently in use:
 
-| scope                          | used for                                                      |
-|--------------------------------|---------------------------------------------------------------|
-| chat:read                      | Read messages from chat (via IRC/TMI).                        |
-| chat:edit                      | Send messages to chat (via IRC/TMI).                          |
-| user:bot                       | Appear in chat as bot.                                        |
-| user:read:chat                 | Read messages from chat. (via EventSub)                       |
-| user:write:chat                | Send messages to chat. (via Twitch API)                       |
-| user:manage:whispers           | Sending and receiving whispers.                               |
-| moderator:read:chatters        | Read the chatters list in the channel (e.g. for badge drops). |
-| moderator:read:followers       | Read the followers list (currently old core).                 |
-| moderator:manage:banned_users  | Timeout, ban and unban users (tpp automod, mod commands).     |
-| moderator:manage:chat_messages | Delete chat messages (tpp automod, purge invalid bets).       |
-| moderator:manage:chat_settings | Change chat settings, e.g. emote-only mode (mod commands).    |
-| channel:read:subscriptions     | Reacting to incoming subscriptions                            |
+| scope                           | used for                                                      | account  |
+|---------------------------------|---------------------------------------------------------------|----------|
+| chat:read                       | Read messages from chat (via IRC/TMI).                        | chat bot |
+| chat:edit                       | Send messages to chat (via IRC/TMI).                          | chat bot |
+| user:bot                        | Appear in chat as bot.                                        | chat bot |
+| user:read:chat                  | Read messages from chat. (via EventSub)                       | chat bot |
+| user:write:chat                 | Send messages to chat. (via Twitch API)                       | chat bot |
+| user:manage:whispers            | Sending and receiving whispers.                               | chat bot |
+| moderator:read:chatters         | Read the chatters list in the channel (e.g. for badge drops). | chat bot |
+| moderator:read:followers        | Read the followers list (currently old core).                 | chat bot |
+| moderator:manage:banned_users   | Timeout, ban and unban users (tpp automod, mod commands).     | chat bot |
+| moderator:manage:chat_messages  | Delete chat messages (tpp automod, purge invalid bets).       | chat bot |
+| moderator:manage:chat_settings  | Change chat settings, e.g. emote-only mode (mod commands).    | chat bot |
+| channel:read:subscriptions      | Reacting to incoming subscriptions                            | channel  |
+| channel:read:redemptions        | Reacting to channel point redemptions (e.g. vidclips)         | channel  |
 
 ## modes
 

--- a/TPP.Core/TwitchApi.cs
+++ b/TPP.Core/TwitchApi.cs
@@ -159,7 +159,8 @@ public class TwitchApi(
         ScopeInfo.Bot("moderator:manage:banned_users",  "Timeout, ban and unban users (tpp automod, mod commands)"),
         ScopeInfo.Bot("moderator:manage:chat_messages", "Delete chat messages (tpp automod, purge invalid bets)"),
         ScopeInfo.Bot("moderator:manage:chat_settings", "Change chat settings, e.g. emote-only mode (mod commands)"),
-        ScopeInfo.Channel("channel:read:subscriptions", "Reacting to incoming subscriptions")
+        ScopeInfo.Channel("channel:read:subscriptions", "Reacting to incoming subscriptions"),
+        ScopeInfo.Channel("channel:read:redemptions",   "Reacting to channel point redemptions (e.g. vidclips)"),
     ];
     private static readonly Dictionary<string, ScopeInfo> ScopeInfosPerScope = ScopeInfos
         .ToDictionary(scopeInfo => scopeInfo.Scope, scopeInfo => scopeInfo);

--- a/TPP.Twitch.EventSub/Notifications/ChannelChannelPointsCustomRewardRedemptionAdd.cs
+++ b/TPP.Twitch.EventSub/Notifications/ChannelChannelPointsCustomRewardRedemptionAdd.cs
@@ -1,0 +1,52 @@
+using NodaTime;
+using TPP.Twitch.EventSub.Messages;
+
+namespace TPP.Twitch.EventSub.Notifications;
+
+using static ChannelChannelPointsCustomRewardRedemptionAdd;
+
+/// <summary>
+/// The channel.channel_points_custom_reward_redemption.add subscription type sends a notification when a viewer has redeemed a custom channel points reward on the specified channel.
+/// See <a href="https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchannel_points_custom_reward_redemptionadd">Subscription Types Documentation for 'Channel Points Custom Reward Redemption Add'</a>
+/// </summary>
+public class ChannelChannelPointsCustomRewardRedemptionAdd(NotificationMetadata metadata, NotificationPayload<Condition, Event> payload)
+    : Notification<Condition, Event>(metadata, payload), IHasSubscriptionType
+{
+    public static string SubscriptionType => "channel.channel_points_custom_reward_redemption.add";
+    public static string SubscriptionVersion => "1";
+
+    /// <summary>
+    /// Channel Points Custom Reward Redemption Add Condition
+    /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward redemption add notifications for.</param>
+    /// <param name="RewardId">Optional. Specify a reward id to only receive notifications for a specific reward.</param>
+    /// </summary>
+    public record Condition(string BroadcasterUserId, string? RewardId = null) : EventSub.Condition;
+
+    /// <summary>
+    /// Channel Points Custom Reward Redemption Add Event
+    /// </summary>
+    /// <param name="Id">The redemption identifier.</param>
+    /// <param name="BroadcasterUserId">The requested broadcaster user ID.</param>
+    /// <param name="BroadcasterUserLogin">The requested broadcaster login.</param>
+    /// <param name="BroadcasterUserName">The requested broadcaster display name.</param>
+    /// <param name="UserId">User ID of the user that redeemed the reward.</param>
+    /// <param name="UserLogin">Login of the user that redeemed the reward.</param>
+    /// <param name="UserName">Display name of the user that redeemed the reward.</param>
+    /// <param name="UserInput">The user input provided. Empty string if not provided.</param>
+    /// <param name="Status">Defaults to unfulfilled. Possible values are unknown, unfulfilled, fulfilled, and canceled.</param>
+    /// <param name="Reward">Basic information about the reward that was redeemed, at the time it was redeemed.</param>
+    /// <param name="RedeemedAt">RFC3339 timestamp of when the reward was redeemed.</param>
+    public record Event(
+        string Id,
+        string BroadcasterUserId,
+        string BroadcasterUserLogin,
+        string BroadcasterUserName,
+        string UserId,
+        string UserLogin,
+        string UserName,
+        string UserInput,
+        RedemptionStatus Status,
+        RedemptionReward Reward,
+        Instant RedeemedAt
+    ) : EventSub.Event;
+}

--- a/TPP.Twitch.EventSub/Notifications/ChannelChannelPointsCustomRewardRedemptionUpdate.cs
+++ b/TPP.Twitch.EventSub/Notifications/ChannelChannelPointsCustomRewardRedemptionUpdate.cs
@@ -1,0 +1,52 @@
+using NodaTime;
+using TPP.Twitch.EventSub.Messages;
+
+namespace TPP.Twitch.EventSub.Notifications;
+
+using static ChannelChannelPointsCustomRewardRedemptionUpdate;
+
+/// <summary>
+/// The channel.channel_points_custom_reward_redemption.update subscription type sends a notification when a redemption of a channel points custom reward has been updated for the specified channel.
+/// See <a href="https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchannel_points_custom_reward_redemptionupdate">Subscription Types Documentation for 'Channel Points Custom Reward Redemption Update'</a>
+/// </summary>
+public class ChannelChannelPointsCustomRewardRedemptionUpdate(NotificationMetadata metadata, NotificationPayload<Condition, Event> payload)
+    : Notification<Condition, Event>(metadata, payload), IHasSubscriptionType
+{
+    public static string SubscriptionType => "channel.channel_points_custom_reward_redemption.update";
+    public static string SubscriptionVersion => "1";
+
+    /// <summary>
+    /// Channel Points Custom Reward Redemption Update Condition
+    /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward redemption update notifications for.</param>
+    /// <param name="RewardId">Optional. Specify a reward id to only receive notifications for a specific reward.</param>
+    /// </summary>
+    public record Condition(string BroadcasterUserId, string? RewardId = null) : EventSub.Condition;
+
+    /// <summary>
+    /// Channel Points Custom Reward Redemption Update Event
+    /// </summary>
+    /// <param name="Id">The redemption identifier.</param>
+    /// <param name="BroadcasterUserId">The requested broadcaster user ID.</param>
+    /// <param name="BroadcasterUserLogin">The requested broadcaster login.</param>
+    /// <param name="BroadcasterUserName">The requested broadcaster display name.</param>
+    /// <param name="UserId">User ID of the user that redeemed the reward.</param>
+    /// <param name="UserLogin">Login of the user that redeemed the reward.</param>
+    /// <param name="UserName">Display name of the user that redeemed the reward.</param>
+    /// <param name="UserInput">The user input provided. Empty string if not provided.</param>
+    /// <param name="Status">Will be fulfilled or canceled. Possible values are unknown, unfulfilled, fulfilled, and canceled.</param>
+    /// <param name="Reward">Basic information about the reward that was redeemed, at the time it was redeemed.</param>
+    /// <param name="RedeemedAt">RFC3339 timestamp of when the reward was redeemed.</param>
+    public record Event(
+        string Id,
+        string BroadcasterUserId,
+        string BroadcasterUserLogin,
+        string BroadcasterUserName,
+        string UserId,
+        string UserLogin,
+        string UserName,
+        string UserInput,
+        RedemptionStatus Status,
+        RedemptionReward Reward,
+        Instant RedeemedAt
+    ) : EventSub.Event;
+}

--- a/TPP.Twitch.EventSub/Notifications/Common.cs
+++ b/TPP.Twitch.EventSub/Notifications/Common.cs
@@ -1,0 +1,30 @@
+namespace TPP.Twitch.EventSub.Notifications;
+
+/// <summary>
+/// Basic information about the reward that was redeemed, at the time it was redeemed.
+/// </summary>
+/// <param name="Id">The reward identifier.</param>
+/// <param name="Title">The reward name.</param>
+/// <param name="Cost">The reward cost.</param>
+/// <param name="Prompt">The reward description.</param>
+public record RedemptionReward(
+    string Id,
+    string Title,
+    int Cost,
+    string Prompt
+);
+
+/// <summary>
+/// The status of the redemption. Possible values:
+/// - unknown
+/// - unfulfilled
+/// - fulfilled
+/// - canceled
+/// </summary>
+public enum RedemptionStatus
+{
+    Unknown,
+    Unfulfilled,
+    Fulfilled,
+    Canceled
+}

--- a/TPP.Twitch.EventSub/Parsing.cs
+++ b/TPP.Twitch.EventSub/Parsing.cs
@@ -41,6 +41,8 @@ public static class Parsing
         RegisterSubscriptionType<ChannelSubscriptionMessage>();
         RegisterSubscriptionType<ChannelSubscriptionGift>();
         RegisterSubscriptionType<UserWhisperMessage>();
+        RegisterSubscriptionType<ChannelChannelPointsCustomRewardRedemptionAdd>();
+        RegisterSubscriptionType<ChannelChannelPointsCustomRewardRedemptionUpdate>();
     }
 
     private static readonly Dictionary<string, Type> MessageTypes = new();


### PR DESCRIPTION
I tested with the Twitch-CLI, and the following JSONs were received on the overlay (prettified):

`twitch event trigger channel.channel_points_custom_reward_redemption.add --transport=websocket`:
```json
{
  "type": "channel_point_reward_redemption_add",
  "extra_parameters": {
    "id": "f0b2ab35-f6f9-1771-a82d-423d1cace120",
    "user": {
      "id": "95741618",
      "twitch_display_name": "testFromUser",
      "name": "testFromUser",
      "simple_name": "testFromUser",
      "color": null,
      "first_active_at": "2025-04-21T14:38:43.4356755Z",
      "last_active_at": "2025-04-21T14:38:43.4356755Z",
      "last_message_at": null,
      "last_whisper_received_at": null,
      "pokeyen": 100,
      "tokens": 0,
      "pokeyen_high_score": 0,
      "participation_emblems": [],
      "selected_participation_emblem": null,
      "selected_badge": null,
      "glow_color": null,
      "glow_color_unlocked": false,
      "pokeyen_bet_rank": null,
      "roles": [],
      "is_subscribed": false,
      "months_subscribed": 0,
      "subscription_tier": null,
      "loyalty_league": 0,
      "subscription_updated_at": null,
      "timeout_expiration": null,
      "banned": false,
      "is_bot": false,
      "is_captcha_suspended": false,
      "donor_badge": false
    },
    "user_input": "Test Input From CLI",
    "status": "unfulfilled",
    "reward": {
      "id": "4837774b-5c24-e276-0442-5c48b45e0f5c",
      "title": "Test Reward from CLI",
      "cost": 150,
      "promp": "Redeem Your Test Reward from CLI"
    },
    "redeemed_at": "2025-04-21T14:38:43.3933102Z"
  }
}
```

`twitch event trigger channel.channel_points_custom_reward_redemption.update --transport=websocket`:
```json
{
  "type": "channel_point_reward_redemption_update",
  "extra_parameters": {
    "id": "26b55f21-75d2-f7fe-1c9a-7e93472b8af0",
    "user": {
      "id": "71355891",
      "twitch_display_name": "testFromUser",
      "name": "testFromUser",
      "simple_name": "testFromUser",
      "color": null,
      "first_active_at": "2025-04-21T14:39:11.0606125Z",
      "last_active_at": "2025-04-21T14:39:11.0606125Z",
      "last_message_at": null,
      "last_whisper_received_at": null,
      "pokeyen": 100,
      "tokens": 0,
      "pokeyen_high_score": 0,
      "participation_emblems": [],
      "selected_participation_emblem": null,
      "selected_badge": null,
      "glow_color": null,
      "glow_color_unlocked": false,
      "pokeyen_bet_rank": null,
      "roles": [],
      "is_subscribed": false,
      "months_subscribed": 0,
      "subscription_tier": null,
      "loyalty_league": 0,
      "subscription_updated_at": null,
      "timeout_expiration": null,
      "banned": false,
      "is_bot": false,
      "is_captcha_suspended": false,
      "donor_badge": false
    },
    "user_input": "Test Input From CLI",
    "status": "unfulfilled",
    "reward": {
      "id": "94bee389-48a9-31a4-4088-1580564cde6a",
      "title": "Test Reward from CLI",
      "cost": 150,
      "promp": "Redeem Your Test Reward from CLI"
    },
    "redeemed_at": "2025-04-21T14:39:11.0438618Z"
  }
}
```